### PR TITLE
Check for distribution of Pods on Nodes

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -60,6 +60,10 @@
     prometheusName: '{{$labels.namespace}}/{{$labels.pod}}',
     prometheusOperatorSelector: 'job="prometheus-operator",namespace="' + $._config.namespace + '"',
 
+
+    // If more than 51% of the PODS for a given workload are on the same node
+    kubePodDistributionUnbalancedPercentageThreshold: 51,
+
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however
     // allow you to overcommit if you wish.

--- a/lib/mintel/alerts/kubernetes-resources.libsonnet
+++ b/lib/mintel/alerts/kubernetes-resources.libsonnet
@@ -38,6 +38,27 @@
               severity: 'warning',
             },
           },
+          {
+            alert: 'KubePodDistributionUnbalanced',
+            annotations: {
+              description: 'Pod Distribution for: {{ $labels.created_by_kind }}/{{ $labels.created_by_name}} , {{ $value }}% are on node {{ $labels.node }}',
+              message: 'Pod Distribution for pods is unbalanced',
+              runbook_url: '%(runBookBaseURL)s/core/KubePodDistributionUnbalanced.md' % $._config,
+            },
+            expr: |||
+              100 * (
+                (count by (created_by_kind, created_by_name, node ) (kube_pod_info{created_by_kind!~"<none>|Job"}) > 1) 
+                / 
+                ignoring(node) 
+                  group_left(created_by_kind, created_by_name) 
+                    count by (created_by_kind, created_by_name) (kube_pod_info{created_by_kind!~"<none>|Job"})
+              ) > %(kubePodDistributionUnbalancedPercentageThreshold)s
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+          },
         ],
       },
     ],

--- a/lib/mintel/config.libsonnet
+++ b/lib/mintel/config.libsonnet
@@ -32,5 +32,7 @@
     namespaceOvercommitFactor: 1.5,
     quotaVsNodesOvercommitFactor: self.namespaceOvercommitFactor * 2,
 
+    // If more than 51% of the PODS for a given workload are on the same node
+    kubePodDistributionUnbalancedPercentageThreshold: 51,
   },
 }

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1784,6 +1784,19 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: KubePodDistributionUnbalanced
+      annotations:
+        description: 'Pod Distribution for: {{ $labels.created_by_kind }}/{{ $labels.created_by_name}}
+          , {{ $value }}% are on node {{ $labels.node }}'
+        message: Pod Distribution for pods is unbalanced
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/KubePodDistributionUnbalanced.md
+      expr: "100 * (\n  (count by (created_by_kind, created_by_name, node ) (kube_pod_info{created_by_kind!~\"<none>|Job\"})
+        > 1) \n  / \n  ignoring(node) \n    group_left(created_by_kind, created_by_name)
+        \n      count by (created_by_kind, created_by_name) (kube_pod_info{created_by_kind!~\"<none>|Job\"})\n)
+        > 51\n"
+      for: 15m
+      labels:
+        severity: warning
   - name: mintel-containers.alerts
     rules:
     - alert: ContainerCombinedIoHighOverTime


### PR DESCRIPTION
Will alert if more than 51% of pods for a given workload are on a single node, for example right now on FC1

| Element | Value |
| --- |  --- |
| {created_by_kind="ReplicaSet",created_by_name="kube-dns-6cd7bbdf65",node="gke-fc1-fc1-standard-d1ebc2a0-jbn7"} | 100 |
| {created_by_kind="ReplicaSet",created_by_name="dex-674994f8f6",node="gke-fc1-fc1-standard-d1ebc2a0-jbn7"} | 100 |
| {created_by_kind="ReplicaSet",created_by_name="dex-auth-764779646b",node="gke-fc1-fc1-standard-ae9d63c0-fbg2"} | 100 |
| {created_by_kind="ReplicaSet",created_by_name="review-golang-helloworld-app-644d574f48",node="gke-fc1-fc1-standard-ae9d63c0-fbg2"} | 100 |
| {created_by_kind="ReplicaSet",created_by_name="podinfo-6579946d59",node="gke-fc1-fc1-standard-ae9d63c0-fbg2"} | 100 |
| {created_by_kind="StatefulSet",created_by_name="alertmanager-main",node="gke-fc1-fc1-standard-ae9d63c0-fbg2"} | 66.66666666666666 |