### PR TITLE
Add flux rules to replace elastalert ones

### DIFF
--- a/lib/mintel/alerts/flux.libsonnet
+++ b/lib/mintel/alerts/flux.libsonnet
@@ -8,7 +8,7 @@
             alert: 'FluxDaemonGeneralSyncError',
             annotations: {
               description: 'General flux sync errors',
-              summary: 'Geneirc Flux Daemon sync error',
+              summary: 'General Flux Daemon sync error',
               runbook_url: '%(runBookBaseURL)s/core/flux.md#fluxdaemongeneralsyncerror' % $._config,
             },
             expr: 'delta(flux_daemon_sync_duration_seconds_count{%(fluxJobSelector)s,success="true"}[%(fluxDeltaIntervalMinutes)sm]) < 1' % $._config,

--- a/lib/mintel/alerts/flux.libsonnet
+++ b/lib/mintel/alerts/flux.libsonnet
@@ -1,0 +1,76 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'flux.alerts',
+        rules: [
+          {
+            alert: 'FluxDaemonGeneralSyncError',
+            annotations: {
+              description: 'General flux sync errors',
+              summary: 'Geneirc Flux Daemon sync error',
+              runbook_url: '%(runBookBaseURL)s/core/flux.md#fluxdaemongeneralsyncerror' % $._config,
+            },
+            expr: 'delta(flux_daemon_sync_duration_seconds_count{%(fluxJobSelector)s,success="true"}[%(fluxDeltaIntervalMinutes)sm]) < 1' % $._config,
+            'for': '120m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            alert: 'FluxManifestsSyncError',
+            annotations: {
+              description: 'Flux manifests sync errors',
+              summary: 'Flux Manifests sync error',
+              runbook_url: '%(runBookBaseURL)s/core/flux.md#fluxmanifestssyncerror' % $._config,
+            },
+            expr: 'flux_daemon_sync_manifests{%(fluxJobSelector)s,success="false"} > 0' % $._config,
+            'for': '60m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            alert: 'FluxMemCacheErrors',
+            annotations: {
+              description: 'Flux Errors talking to memcached',
+              summary: 'Flux Errors talking to memcached',
+              runbook_url: '%(runBookBaseURL)s/core/flux.md#fluxmemcacheerrors' % $._config,
+            },
+            expr: 'delta(flux_cache_request_duration_seconds_count{%(fluxJobSelector)s,success="false"}[%(fluxDeltaDoubleIntervalMinutes)sm]) > 0' % $._config,
+            'for': '60m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            alert: 'FluxRemoteFetchErrors',
+            annotations: {
+              description: 'Flux errors fetching from remote registry',
+              summary: 'Flux errors fetching from remote registry',
+              runbook_url: '%(runBookBaseURL)s/core/flux.md#fluxremotefetcherrors' % $._config,
+            },
+            expr: 'delta(flux_client_fetch_duration_seconds_count{%(fluxJobSelector)s,success="false"}[%(fluxDeltaDoubleIntervalMinutes)sm]) > 0' % $._config,
+            'for': '240m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            alert: 'FluxReleaseErrors',
+            annotations: {
+              description: 'Flux image release errors',
+              summary: 'Flux release errors',
+              runbook_url: '%(runBookBaseURL)s/core/flux.md#fluxreleaseerrors' % $._config,
+            },
+            expr: 'delta(flux_fluxsvc_release_duration_seconds_count{%(fluxJobSelector)s,success="false"}[%(fluxDeltaIntervalMinutes)sm]) > 0' % $._config,
+            'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/lib/mintel/config.libsonnet
+++ b/lib/mintel/config.libsonnet
@@ -34,5 +34,10 @@
 
     // If more than 51% of the PODS for a given workload are on the same node
     kubePodDistributionUnbalancedPercentageThreshold: 51,
+
+    // Flux Vars
+    fluxJobSelector: 'job="flux"',
+    fluxDeltaIntervalMinutes: 6,
+    fluxDeltaDoubleIntervalMinutes: 2 * this.fluxDeltaIntervalMinutes,
   },
 }

--- a/lib/mintel/mixins.libsonnet
+++ b/lib/mintel/mixins.libsonnet
@@ -12,6 +12,7 @@
 (import './alerts/mintel-overcommit.libsonnet') +
 (import './alerts/mintel-pod.libsonnet') +
 (import './alerts/mintel-web-frontend.libsonnet') +
+(import './alerts/flux.libsonnet') +
 
 (import './rules/blackbox.libsonnet') +
 (import './rules/elasticsearch.libsonnet') +

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1916,7 +1916,7 @@ spec:
       annotations:
         description: General flux sync errors
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/flux.md#fluxdaemongeneralsyncerror
-        summary: Geneirc Flux Daemon sync error
+        summary: General Flux Daemon sync error
       expr: delta(flux_daemon_sync_duration_seconds_count{job="flux",success="true"}[6m])
         < 1
       for: 120m

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1910,3 +1910,54 @@ spec:
       for: 1m
       labels:
         severity: critical
+  - name: flux.alerts
+    rules:
+    - alert: FluxDaemonGeneralSyncError
+      annotations:
+        description: General flux sync errors
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/flux.md#fluxdaemongeneralsyncerror
+        summary: Geneirc Flux Daemon sync error
+      expr: delta(flux_daemon_sync_duration_seconds_count{job="flux",success="true"}[6m])
+        < 1
+      for: 120m
+      labels:
+        severity: warning
+    - alert: FluxManifestsSyncError
+      annotations:
+        description: Flux manifests sync errors
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/flux.md#fluxmanifestssyncerror
+        summary: Flux Manifests sync error
+      expr: flux_daemon_sync_manifests{job="flux",success="false"} > 0
+      for: 60m
+      labels:
+        severity: warning
+    - alert: FluxMemCacheErrors
+      annotations:
+        description: Flux Errors talking to memcached
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/flux.md#fluxmemcacheerrors
+        summary: Flux Errors talking to memcached
+      expr: delta(flux_cache_request_duration_seconds_count{job="flux",success="false"}[12m])
+        > 0
+      for: 60m
+      labels:
+        severity: warning
+    - alert: FluxRemoteFetchErrors
+      annotations:
+        description: Flux errors fetching from remote registry
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/flux.md#fluxremotefetcherrors
+        summary: Flux errors fetching from remote registry
+      expr: delta(flux_client_fetch_duration_seconds_count{job="flux",success="false"}[12m])
+        > 0
+      for: 240m
+      labels:
+        severity: warning
+    - alert: FluxReleaseErrors
+      annotations:
+        description: Flux image release errors
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/flux.md#fluxreleaseerrors
+        summary: Flux release errors
+      expr: delta(flux_fluxsvc_release_duration_seconds_count{job="flux",success="false"}[6m])
+        > 0
+      for: 10m
+      labels:
+        severity: warning


### PR DESCRIPTION
Monitor multiple sides of Flux 

Try to only alert if the problems persist for a while, the only *short* one is the autorelease one 

All severity is set to warning since flux errors *should not* impact anything live