### PR TITLE
Fix haproxy web app panel

### DIFF
--- a/dashboards/rendered/image-service-overview.json
+++ b/dashboards/rendered/image-service-overview.json
@@ -239,7 +239,7 @@
                "dashes": false,
                "datasource": "$ds",
                "decimals": 2,
-               "description": "HAProxy HTTP Responses",
+               "description": "Percentile Latency",
                "fill": 0,
                "gridPos": {
                   "h": 10,
@@ -277,18 +277,34 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (backend, code)\n  (irate(\n    haproxy_backend_http_responses_total{backend=~\"$namespace-.*$deployment-[0-9].*\",}[5m]))\n",
+                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      http_backend_request_duration_seconds_bucket{backend=~\"$namespace-.*$deployment-[0-9].*\"}[5m]))\nby (backend,job,le))\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
-                     "legendFormat": "",
+                     "legendFormat": "p95 {{ backend }}",
                      "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    http_backend_request_duration_seconds_bucket{backend=~\"$namespace-.*$deployment-[0-9].*\"}[5m]))\nby (backend,job,le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p75 {{ backend }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    http_backend_request_duration_seconds_bucket{backend=~\"$namespace-.*$deployment-[0-9].*\"}[5m]))\nby (backend,job,le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p50 {{ backend }}",
+                     "refId": "C"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "HAProxy HTTP Responses",
+               "title": "HAProxy Latency",
                "tooltip": {
                   "shared": true,
                   "sort": 2,

--- a/dashboards/rendered/portal-overview.json
+++ b/dashboards/rendered/portal-overview.json
@@ -239,7 +239,7 @@
                "dashes": false,
                "datasource": "$ds",
                "decimals": 2,
-               "description": "HAProxy HTTP Responses",
+               "description": "Percentile Latency",
                "fill": 0,
                "gridPos": {
                   "h": 10,
@@ -277,18 +277,34 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (backend, code)\n  (irate(\n    haproxy_backend_http_responses_total{backend=~\"$namespace-.*$service-[0-9].*\",}[5m]))\n",
+                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      http_backend_request_duration_seconds_bucket{backend=~\"$namespace-.*$service-[0-9].*\"}[5m]))\nby (backend,job,le))\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
-                     "legendFormat": "",
+                     "legendFormat": "p95 {{ backend }}",
                      "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    http_backend_request_duration_seconds_bucket{backend=~\"$namespace-.*$service-[0-9].*\"}[5m]))\nby (backend,job,le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p75 {{ backend }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    http_backend_request_duration_seconds_bucket{backend=~\"$namespace-.*$service-[0-9].*\"}[5m]))\nby (backend,job,le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p50 {{ backend }}",
+                     "refId": "C"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "HAProxy HTTP Responses",
+               "title": "HAProxy Latency",
                "tooltip": {
                   "shared": true,
                   "sort": 2,

--- a/lib/mintel/dashboards/components/panels/haproxy.libsonnet
+++ b/lib/mintel/dashboards/components/panels/haproxy.libsonnet
@@ -2,56 +2,55 @@ local commonPanels = import 'components/panels/common.libsonnet';
 local layout = import 'components/layout.libsonnet';
 local promQuery = import 'components/prom_query.libsonnet';
 {
-  overview(serviceSelectorKey="service", serviceSelectorValue="$service", startRow=1000)::
+  latencyTimeseries(serviceSelectorKey="service", serviceSelectorValue="$service", span=12)::
       local config = {
         serviceSelectorKey: serviceSelectorKey,
         serviceSelectorValue: serviceSelectorValue
     };
-  
-    layout.grid([
-      commonPanels.latencyTimeseries(
-        title='HAProxy Latency',
-        description='Percentile Latency',
-        yAxisLabel='Time',
-        format='s',
-        span=12,
-        legend_show=false,
-        height=200,
-        query=|||
-          histogram_quantile(0.95, 
-            sum(
-              rate(
-                http_backend_request_duration_seconds_bucket{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[5m]))
+
+    commonPanels.latencyTimeseries(
+      title='HAProxy Latency',
+      description='Percentile Latency',
+      yAxisLabel='Time',
+      format='s',
+      span=span,
+      legend_show=false,
+      height=200,
+      query=|||
+        histogram_quantile(0.95,
+          sum(
+            rate(
+              http_backend_request_duration_seconds_bucket{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[5m]))
+        by (backend,job,le))
+      ||| % config,
+    legendFormat='p95 {{ backend }}',
+    intervalFactor=2,
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.75,
+          sum(
+            rate(
+              http_backend_request_duration_seconds_bucket{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[5m]))
           by (backend,job,le))
         ||| % config,
-      legendFormat='p95 {{ backend }}',
-      intervalFactor=2,
+        legendFormat='p75 {{ backend }}',
+        intervalFactor=2,
       )
-      .addTarget(
-        promQuery.target(
-          |||
-            histogram_quantile(0.75,
-            sum(
-              rate(
-                http_backend_request_duration_seconds_bucket{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[5m]))
-            by (backend,job,le))
-          ||| % config,
-          legendFormat='p75 {{ backend }}',
-          intervalFactor=2,
-        )
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.50,
+          sum(
+            rate(
+              http_backend_request_duration_seconds_bucket{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[5m]))
+          by (backend,job,le))
+        ||| % config,
+        legendFormat='p50 {{ backend }}',
+        intervalFactor=2,
       )
-      .addTarget(
-        promQuery.target(
-          |||
-            histogram_quantile(0.50,
-            sum(
-              rate(
-                http_backend_request_duration_seconds_bucket{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[5m]))
-            by (backend,job,le))
-          ||| % config,
-          legendFormat='p50 {{ backend }}',
-          intervalFactor=2,
-        )
-      ),
-    ], cols=1, rowHeight=250, startRow=startRow+1)
+    ),
+  
 }

--- a/lib/mintel/dashboards/components/panels/web-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/web-service.libsonnet
@@ -1,4 +1,5 @@
 local commonPanels = import 'components/panels/common.libsonnet';
+local haproxyPanels = import 'components/panels/haproxy.libsonnet';
 local layout = import 'components/layout.libsonnet';
 {
 
@@ -41,21 +42,6 @@ local layout = import 'components/layout.libsonnet';
         ||| % config,
       ),
 
-    commonPanels.latencyTimeseries(
-        title='HAProxy HTTP Responses',
-        description='HAProxy HTTP Responses',
-        yAxisLabel='Time',
-        format='s',
-        span=7,
-        legend_show=false,
-        height=200,
-        query=|||
-          sum by (backend, code)
-            (irate(
-              haproxy_backend_http_responses_total{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*",}[5m]))
-        ||| % config,
-
-      intervalFactor=2,
-      )
+    haproxyPanels.latencyTimeseries(config.service, config.serviceSelectorValue, span=7)
     ], cols=12, rowHeight=10, startRow=startRow),
 }


### PR DESCRIPTION
- The HAProxy graph was showing number of requests, it was wrong (should have been showing percentiles)
- Made django app request mimic haproxy in terms of percentiles.
- Tried to tidy up y-axis and use correct format where possible