### PR TITLE
Disk device update

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -49,8 +49,8 @@
     hostMountpointSelector: 'mountpoint="/mnt/stateful_partition"',
 
     // This list of disk device names is referenced in various expressions.
-    diskDevices: ['/dev/sda1'],
-    diskDeviceSelector: 'device=~"/dev/sda1"',
+    diskDevices: ['sda'],
+    diskDeviceSelector: 'device=~"sda"',
 
     /// Same, but for node-mixin
     fsSelector: self.fstypeSelector,

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,7 +1,6 @@
 {
   "dependencies": [
     {
-      "name": "kube-prometheus",
       "source": {
         "git": {
           "remote": "https://github.com/coreos/kube-prometheus",
@@ -11,7 +10,15 @@
       "version": "5e1758c45380093f412c751aa6781ca88f02b59e"
     },
     {
-      "name": "node-mixin",
+      "source": {
+        "git": {
+          "remote": "https://github.com/coreos/prometheus-operator",
+          "subdir": "jsonnet/prometheus-operator"
+        }
+      },
+      "version": "18fbf558ab7f8809fd610a3dc50bf483508dc1bb"
+    },
+    {
       "source": {
         "git": {
           "remote": "https://github.com/prometheus/node_exporter",
@@ -21,24 +28,15 @@
       "version": "855a1f1d18b82f24c1e517da44ef36f2ffa35b19"
     },
     {
-      "name": "prometheus",
       "source": {
         "git": {
           "remote": "https://github.com/prometheus/prometheus",
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "08c55c119f39093e18b2bb9cba5c5619dc4ea0e1"
-    },
-    {
-      "name": "prometheus-operator",
-      "source": {
-        "git": {
-          "remote": "https://github.com/coreos/prometheus-operator",
-          "subdir": "jsonnet/prometheus-operator"
-        }
-      },
-      "version": "18fbf558ab7f8809fd610a3dc50bf483508dc1bb"
+      "version": "08c55c119f39093e18b2bb9cba5c5619dc4ea0e1",
+      "name": "prometheus"
     }
-  ]
+  ],
+  "legacyImports": true
 }

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -44,10 +44,10 @@ spec:
         )
       record: instance:node_memory_swap_io_pages:rate1m
     - expr: |
-        rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"/dev/sda1"}[1m])
+        rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"sda"}[1m])
       record: instance_device:node_disk_io_time_seconds:rate1m
     - expr: |
-        rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"/dev/sda1"}[1m])
+        rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"sda"}[1m])
       record: instance_device:node_disk_io_time_weighted_seconds:rate1m
     - expr: |
         sum without (device) (
@@ -262,21 +262,21 @@ spec:
         )
       record: node:node_memory_swap_io_bytes:sum_rate
     - expr: |
-        avg(irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"/dev/sda1"}[1m]))
+        avg(irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"sda"}[1m]))
       record: :node_disk_utilisation:avg_irate
     - expr: |
         avg by (node) (
-          irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"/dev/sda1"}[1m])
+          irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"sda"}[1m])
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )
       record: node:node_disk_utilisation:avg_irate
     - expr: |
-        avg(irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"/dev/sda1"}[1m]))
+        avg(irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"sda"}[1m]))
       record: :node_disk_saturation:avg_irate
     - expr: |
         avg by (node) (
-          irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"/dev/sda1"}[1m])
+          irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"sda"}[1m])
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:
         )


### PR DESCRIPTION
The disk devices were configured incorrectly in the config.libsonnet file.  They were set like this:
    diskDevices: ['/dev/sda1'],
    diskDeviceSelector: 'device=~"/dev/sda1"',

which was causing the Prometheus query to return no data.  I have updated them to:
    diskDevices: ['sda'],
    diskDeviceSelector: 'device=~"sda"',