### PR TITLE
Remove the byZone rule for now because it triggers too many false positives

### DIFF
--- a/lib/gke-overrides.libsonnet
+++ b/lib/gke-overrides.libsonnet
@@ -8,6 +8,7 @@ local ignore_alerts = [
   'KubeClientErrors',
   'KubeClientCertificateExpiration',
   'KubeControllerManagerDown',
+  'KubePodDistributionUnbalancedByZone',
   'KubeSchedulerDown',
   'NodeNetworkReceiveErrs',
   'NodeNetworkTransmitErrs',

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1862,21 +1862,6 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: KubePodDistributionUnbalancedByZone
-      annotations:
-        description: 'Pod Distribution for: {{ $labels.created_by_kind }}/{{ $labels.created_by_name}}
-          , {{ $value }}% are in zone {{ $labels.label_failure_domain_beta_kubernetes_io_zone
-          }}'
-        message: Pod Distribution for pods is unbalanced in the availability zones
-        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/KubePodDistributionUnbalancedByZone.md
-      expr: "100 * (\n  (count by(created_by_kind, created_by_name, label_failure_domain_beta_kubernetes_io_zone)
-        \n    (kube_pod_info{created_by_kind!~\"<none>|Job\"} * on(node) \n     group_left(label_failure_domain_beta_kubernetes_io_zone)
-        kube_node_labels) > 1 )\n  / \n  ignoring(label_failure_domain_beta_kubernetes_io_zone)
-        group_left(created_by_kind, created_by_name) \n    count by(created_by_kind,
-        created_by_name) (kube_pod_info{created_by_kind!~\"<none>|Job\"})\n) > 50\n"
-      for: 15m
-      labels:
-        severity: warning
   - name: mintel-containers.alerts
     rules:
     - alert: ContainerCombinedIoHighOverTime


### PR DESCRIPTION

for example `{created_by_kind="ReplicaSet",created_by_name="haproxy-fluentd-78bdf989d9",label_failure_domain_beta_kubernetes_io_zone="europe-west1-b"}` which are hard to fix