### PR TITLE
Add pre-recording quantile for http backend requests

### DIFF
--- a/lib/mintel/dashboards/components/panels/haproxy.libsonnet
+++ b/lib/mintel/dashboards/components/panels/haproxy.libsonnet
@@ -54,6 +54,45 @@ local promQuery = import 'components/prom_query.libsonnet';
       )
     ),
 
+  latencyTimeseriesPreRecorded(serviceSelectorKey='service', serviceSelectorValue='$service', span=12)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+
+    commonPanels.latencyTimeseries(
+      title='HAProxy Latency',
+      description='Percentile Latency from HAProxy Ingress',
+      yAxisLabel='Time',
+      format='s',
+      span=span,
+      legend_show=false,
+      height=200,
+      query=|||
+        haproxy:http_backend_request_seconds_quantile:95{mintel_com_service="$namespace-%(serviceSelectorValue)s"}
+      ||| % config,
+      legendFormat='p95 {{ backend }}',
+      intervalFactor=2,
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          haproxy:http_backend_request_seconds_quantile:75{mintel_com_service="$namespace-%(serviceSelectorValue)s"}
+        ||| % config,
+        legendFormat='p75 {{ backend }}',
+        intervalFactor=2,
+      )
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          haproxy:http_backend_request_seconds_quantile:50{mintel_com_service="$namespace-%(serviceSelectorValue)s"}
+        ||| % config,
+        legendFormat='p50 {{ backend }}',
+        intervalFactor=2,
+      )
+    ),
+
   httpResponseStatusTimeseries(serviceSelectorKey='service', serviceSelectorValue='$service', interval='5m', span=12)::
     local config = {
       serviceSelectorKey: serviceSelectorKey,

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -307,6 +307,34 @@ spec:
     - expr: "100 * (\n  sum by (frontend) (haproxy_frontend_current_sessions) \n  /
         \n  sum by (frontend) (haproxy_frontend_limit_sessions)\n)\n"
       record: haproxy:http_frontend_session_usage:percentage
+    - expr: |
+        label_replace(
+        histogram_quantile(0.50,sum (rate(http_backend_request_duration_seconds_bucket{backend!~"(error|stats|.*default-backend)"}[1m])) by (backend,job,le)),
+        "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
+        * on(mintel_com_service) group_left(label_app_mintel_com_owner)
+        label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:http_backend_request_seconds_quantile:50
+    - expr: |
+        label_replace(
+        histogram_quantile(0.75,sum (rate(http_backend_request_duration_seconds_bucket{backend!~"(error|stats|.*default-backend)"}[1m])) by (backend,job,le)),
+        "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
+        * on(mintel_com_service) group_left(label_app_mintel_com_owner)
+        label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:http_backend_request_seconds_quantile:75
+    - expr: |
+        label_replace(
+        histogram_quantile(0.95,sum (rate(http_backend_request_duration_seconds_bucket{backend!~"(error|stats|.*default-backend)"}[1m])) by (backend,job,le)),
+        "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
+        * on(mintel_com_service) group_left(label_app_mintel_com_owner)
+        label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:http_backend_request_seconds_quantile:95
+    - expr: |
+        label_replace(
+        histogram_quantile(0.99,sum (rate(http_backend_request_duration_seconds_bucket{backend!~"(error|stats|.*default-backend)"}[1m])) by (backend,job,le)),
+        "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
+        * on(mintel_com_service) group_left(label_app_mintel_com_owner)
+        label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:http_backend_request_seconds_quantile:99
   - name: mintel-disk.rules
     rules:
     - expr: |


### PR DESCRIPTION
Pre-Record the quantile to hopefully make the graphing much faster

![screencapture-prometheus-svc-eu-prod1-gke-mintelcloud-io-graph-2020-04-16-10_20_30](https://user-images.githubusercontent.com/2085772/79432404-03153980-7fcc-11ea-9c7a-34e345ded91f.png)
