### PR TITLE
Haproxy recording and alerting rules review 

### DIFF
--- a/dashboards/rendered/prometheus-performances.json
+++ b/dashboards/rendered/prometheus-performances.json
@@ -103,19 +103,19 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (pod) (\n  irate(container_cpu_usage_seconds_total{namespace=\"monitoring\", pod=~\"$prometheus\", image!=\"\", job=\"kubelet\", container=~\"prometheus\", container!=\"POD\"}[1m])\n)\n",
+                     "expr": "sum by (pod) (\n  rate(container_cpu_usage_seconds_total{namespace=\"monitoring\", pod=~\"$prometheus\", image!=\"\", job=\"kubelet\", container=~\"prometheus\", container!=\"POD\"}[1m])\n)\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 1,
-                     "legendFormat": "Current irate 1m - {{ pod }}",
+                     "legendFormat": "Current rate 1m - {{ pod }}",
                      "refId": "A"
                   },
                   {
-                     "expr": "sum by (pod) (\n  rate(container_cpu_usage_seconds_total{namespace=\"monitoring\", pod=~\"$prometheus\", image!=\"\", job=\"kubelet\", container=~\"prometheus\", container!=\"POD\"}[$__interval])\n)\n",
+                     "expr": "sum by (pod) (\n  rate(container_cpu_usage_seconds_total{namespace=\"monitoring\", pod=~\"$prometheus\", image!=\"\", job=\"kubelet\", container=~\"prometheus\", container!=\"POD\"}[5m])\n)\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
-                     "legendFormat": "Current rate $__interval - {{ pod }}",
+                     "legendFormat": "Current rate 5m - {{ pod }}",
                      "refId": "B"
                   },
                   {

--- a/lib/mintel/alerts/haproxy-ingress.libsonnet
+++ b/lib/mintel/alerts/haproxy-ingress.libsonnet
@@ -170,9 +170,7 @@
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyServerInBackendUpPercentageLow' % $._config,
               summary: 'HAProxy: The percentage of server up in backend for {{ $labels.mintel_com_service }} service is low on ingress {{ $labels.pod }} : {{ $value }}%',
             },
-            expr: |||
-              haproxy:haproxy_server_up:percentage < 75
-            |||,
+            expr: 'haproxy:haproxy_server_up:percentage < 75',
             'for': '5m',
             labels: {
               severity: 'warning',
@@ -184,10 +182,7 @@
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyServerInBackendUpPercentageLow' % $._config,
               summary: 'HAProxy: The percentage of server up in backend for {{ $labels.mintel_com_service }} service is low on ingress {{ $labels.pod }} : {{ $value }}%',
             },
-            expr: |||
-              (
-              haproxy:haproxy_server_up:percentage < 50
-            |||,
+            expr: 'haproxy:haproxy_server_up:percentage < 50',
             'for': '5m',
             labels: {
               severity: 'critical',

--- a/lib/mintel/alerts/haproxy-ingress.libsonnet
+++ b/lib/mintel/alerts/haproxy-ingress.libsonnet
@@ -105,48 +105,12 @@
             },
           },
           {
-            alert: 'HAProxyBackendRequestQueued',
-            annotations: {
-              runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendRequestQueued' % $._config,
-              summary: 'HAProxy: Request are queuing up on the {{ $labels.mintel_com_service }} backend',
-            },
-            expr: 'sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_current_queue:labeled) > 100',
-            'for': '10m',
-            labels: {
-              severity: 'critical',
-            },
-          },
-          {
-            alert: 'HAProxyBackendRequestQueuedTime',
-            annotations: {
-              runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendRequestQueuedTime' % $._config,
-              summary: 'HAProxy: Excessive request queue time on the {{ $labels.mintel_com_service }} backend',
-            },
-            expr: 'haproxy:http_backend_queue_time_seconds_bucket:histogram_quantile > 0.3',
-            'for': '2m',
-            labels: {
-              severity: 'warning',
-            },
-          },
-          {
-            alert: 'HAProxyBackendRequestQueuedTime',
-            annotations: {
-              runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendRequestQueuedTime' % $._config,
-              summary: 'HAProxy: Excessive request queue time on the {{ $labels.mintel_com_service }} backend',
-            },
-            expr: 'haproxy:http_backend_queue_time_seconds_bucket:histogram_quantile > 0.5',
-            'for': '10m',
-            labels: {
-              severity: 'critical',
-            },
-          },
-          {
             alert: 'HAProxyBackendResponseErrors',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendResponseErrors' % $._config,
               summary: 'HAProxy: Response errors detected on {{ $labels.mintel_com_service }} backend',
             },
-            expr: 'sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_response_errors_total:labeled[1m])) > 1',
+            expr: 'haproxy:haproxy_backend_response_errors_total:rate:1m > 1',
             'for': '2m',
             labels: {
               severity: 'warning',
@@ -158,7 +122,7 @@
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendResponseErrors' % $._config,
               summary: 'HAProxy: Response errors detected on {{ $labels.mintel_com_service }} backend',
             },
-            expr: 'sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_response_errors_total:labeled[1m])) > 10',
+            expr: 'haproxy:haproxy_backend_response_errors_total:rate:1m > 10',
             'for': '10m',
             labels: {
               severity: 'critical',
@@ -170,13 +134,7 @@
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendResponseErrors5xx' % $._config,
               summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service }} service',
             },
-            expr: |||
-              (
-              sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled{code=~"5.."}[1m]))
-              /
-              sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled[1m]))
-              ) * 100 > 1
-            |||,
+            expr: 'haproxy:haproxy_backend_http_responses_total:percentage:1m > 1',
             'for': '5m',
             labels: {
               severity: 'warning',
@@ -188,13 +146,7 @@
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendResponseErrors5xx' % $._config,
               summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service }} service',
             },
-            expr: |||
-              (
-              sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled{code=~"5.."}[1m]))
-              /
-              sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled[1m]))
-              ) * 100 > 10
-            |||,
+            expr: 'haproxy:haproxy_backend_http_responses_total:percentage:1m > 10',
             'for': '10m',
             labels: {
               severity: 'critical',
@@ -206,7 +158,7 @@
               description: 'HAProxy: {{ $labels.mintel_com_service }} backend has been down for at least 1m on all Ingress pods',
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendDown' % $._config,
             },
-            expr: 'sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_up:labeled) == 0',
+            expr: 'sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_up:counter) == 0',
             'for': '5m',
             labels: {
               severity: 'critical',
@@ -219,11 +171,7 @@
               summary: 'HAProxy: The percentage of server up in backend for {{ $labels.mintel_com_service }} service is low on ingress {{ $labels.pod }} : {{ $value }}%',
             },
             expr: |||
-              (
-              sum by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)
-              /
-              count by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)
-              ) * 100 < 75 
+              haproxy:haproxy_server_up:percentage < 75
             |||,
             'for': '5m',
             labels: {
@@ -238,10 +186,7 @@
             },
             expr: |||
               (
-              sum by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)
-              /
-              count by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)
-              ) * 100 < 50
+              haproxy:haproxy_server_up:percentage < 50
             |||,
             'for': '5m',
             labels: {

--- a/lib/mintel/alerts/haproxy-ingress.libsonnet
+++ b/lib/mintel/alerts/haproxy-ingress.libsonnet
@@ -93,18 +93,6 @@
             },
           },
           {
-            alert: 'HAProxyBackendRequestQueued',
-            annotations: {
-              runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendRequestQueued' % $._config,
-              summary: 'HAProxy: Request are queuing up on the {{ $labels.mintel_com_service }} backend',
-            },
-            expr: 'sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_current_queue:labeled) > 10',
-            'for': '2m',
-            labels: {
-              severity: 'warning',
-            },
-          },
-          {
             alert: 'HAProxyBackendResponseErrors',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendResponseErrors' % $._config,

--- a/lib/mintel/alerts/image-service.libsonnet
+++ b/lib/mintel/alerts/image-service.libsonnet
@@ -8,7 +8,7 @@
             alert: 'ImageServiceHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: 95th percentile of response times increased to 5s on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times is more than 5s on {{ $labels.mintel_com_service }} backend.',
             },
             expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"} > 5',
             'for': '5m',
@@ -20,7 +20,7 @@
             alert: 'ImageServiceHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: 95th percentile of response times increased to 1s on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times is more than 1s on {{ $labels.mintel_com_service }} backend.',
             },
             expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"} > 1',
             'for': '10m',

--- a/lib/mintel/alerts/image-service.libsonnet
+++ b/lib/mintel/alerts/image-service.libsonnet
@@ -8,10 +8,10 @@
             alert: 'ImageServiceHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times increased to 5s on {{ $labels.mintel_com_service }} backend.',
             },
-            expr: 'haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="moat", mintel_com_service=~".*image-service.*"} > 5\n',
-            'for': '2m',
+            expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"} > 5',
+            'for': '5m',
             labels: {
               severity: 'critical',
             },
@@ -20,10 +20,10 @@
             alert: 'ImageServiceHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times increased to 1s on {{ $labels.mintel_com_service }} backend.',
             },
-            expr: 'haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="moat", mintel_com_service=~".*image-service.*"} > 1\n',
-            'for': '5m',
+            expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"} > 1',
+            'for': '10m',
             labels: {
               severity: 'warning',
             },

--- a/lib/mintel/alerts/portal.libsonnet
+++ b/lib/mintel/alerts/portal.libsonnet
@@ -8,7 +8,7 @@
             alert: 'PortalHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: 95th percentile of response times increased to 0.5s on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times is more than 0.5s on {{ $labels.mintel_com_service }} backend.',
             },
             expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"} > 0.5',
             'for': '10m',
@@ -20,7 +20,7 @@
             alert: 'PortalHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: 95th percentile of response times increased to 1s on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times is more than 1s on {{ $labels.mintel_com_service }} backend.',
             },
             expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"} > 1',
             'for': '5m',

--- a/lib/mintel/alerts/portal.libsonnet
+++ b/lib/mintel/alerts/portal.libsonnet
@@ -8,10 +8,10 @@
             alert: 'PortalHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times increased to 0.5s on {{ $labels.mintel_com_service }} backend.',
             },
-            expr: 'haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="portal",mintel_com_service=~".*-portal-web"} > 0.5\n',
-            'for': '5m',
+            expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"} > 0.5',
+            'for': '10m',
             labels: {
               severity: 'warning',
             },
@@ -20,10 +20,10 @@
             alert: 'PortalHAProxyBackendResponseTime',
             annotations: {
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#haproxybackendresponsetime' % $._config,
-              summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service }} backend.',
+              summary: 'HAProxy: 95th percentile of response times increased to 1s on {{ $labels.mintel_com_service }} backend.',
             },
-            expr: 'haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="portal",mintel_com_service=~".*-portal-web"} > 1\n',
-            'for': '30m',
+            expr: 'haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"} > 1',
+            'for': '5m',
             labels: {
               severity: 'critical',
             },

--- a/lib/mintel/dashboards/components/panels/containers.libsonnet
+++ b/lib/mintel/dashboards/components/panels/containers.libsonnet
@@ -5,7 +5,7 @@ local seriesOverrides = import 'components/series_overrides.libsonnet';
 
 {
 
-  podResourcesRow(namespace, pod, container='.*', title='', interval='$__interval', startRow=1000)::
+  podResourcesRow(namespace, pod, container='.*', title='', interval='5m', startRow=1000)::
     local config = {
       kubeletSelector: std.format('namespace="%s", pod=~"%s", image!="", job="kubelet", container=~"%s", container!="POD"', [namespace, pod, container]),
       kubeStateSelector: std.format('namespace="%s", pod=~"%s", container=~"%s", job="kube-state-metrics"', [namespace, pod, container]),
@@ -67,10 +67,10 @@ local seriesOverrides = import 'components/series_overrides.libsonnet';
         legend_show=false,
         query=|||
           sum by (pod) (
-            irate(container_cpu_usage_seconds_total{%(kubeletSelector)s}[1m])
+            rate(container_cpu_usage_seconds_total{%(kubeletSelector)s}[1m])
           )
         ||| % config,
-        legendFormat='Current irate 1m - {{ pod }}',
+        legendFormat='Current rate 1m - {{ pod }}',
         intervalFactor=1,
       )
       .addTarget(

--- a/lib/mintel/rules/haproxy-ingress.libsonnet
+++ b/lib/mintel/rules/haproxy-ingress.libsonnet
@@ -14,7 +14,7 @@
           },
           {
             expr: |||
-              sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_response_errors_total:counter[1m]))
+              sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_response_errors_total:counter[1m]))
             |||,
             record: 'haproxy:haproxy_backend_response_errors_total:rate:1m',
           },
@@ -29,9 +29,9 @@
           {
             expr: |||
               (
-              sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter{code=~"5.."}[1m]))
+              sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_http_responses_total:counter{code=~"5.."}[1m]))
               /
-              sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
+              sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
               ) * 100
             |||,
             record: 'haproxy:haproxy_backend_http_responses_total:percentage:1m',

--- a/lib/mintel/rules/haproxy-ingress.libsonnet
+++ b/lib/mintel/rules/haproxy-ingress.libsonnet
@@ -6,126 +6,68 @@
         rules: [
           {
             expr: |||
-              label_replace(
-              label_replace(http_backend_response_wait_seconds_bucket{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
-              * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-              "label_app_mintel_com_owner",
-              "satoshi",
-              "label_app_mintel_com_owner",
-              ""
-              )
-            |||,
-            record: 'haproxy:http_backend_response_wait_seconds_bucket:labeled',
-          },
-          {
-            expr: |||
-              label_replace(
-              label_replace(http_backend_queue_time_seconds_bucket{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
-                * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-              "label_app_mintel_com_owner",
-              "satoshi",
-              "label_app_mintel_com_owner",
-              ""
-              )
-            |||,
-            record: 'haproxy:http_backend_queue_time_seconds_bucket:labeled',
-          },
-          {
-            expr: |||
-              label_replace(
-              label_replace(haproxy_backend_current_queue{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
-                * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-              "label_app_mintel_com_owner",
-              "satoshi",
-              "label_app_mintel_com_owner",
-              ""
-              )
-            |||,
-            record: 'haproxy:haproxy_backend_current_queue:labeled',
-          },
-          {
-            expr: |||
-              label_replace(
               label_replace(haproxy_backend_response_errors_total{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
                 * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-              "label_app_mintel_com_owner",
-              "satoshi",
-              "label_app_mintel_com_owner",
-              ""
+                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
               )
             |||,
-            record: 'haproxy:haproxy_backend_response_errors_total:labeled',
+            record: 'haproxy:haproxy_backend_response_errors_total:counter',
           },
           {
             expr: |||
-              label_replace(
+              sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_response_errors_total:counter[1m]))
+            |||,
+            record: 'haproxy:haproxy_backend_response_errors_total:rate:1m',
+          },
+          {
+            expr: |||
               label_replace(haproxy_backend_http_responses_total{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
                 * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-              "label_app_mintel_com_owner",
-              "satoshi",
-              "label_app_mintel_com_owner",
-              ""
-              )
+                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
             |||,
-            record: 'haproxy:haproxy_backend_http_responses_total:labeled',
+            record: 'haproxy:haproxy_backend_http_responses_total:counter',
           },
           {
             expr: |||
-              label_replace(
+              sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter{code=~"5.."}[1m]))
+              /
+              sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
+              ) * 100
+            |||,
+            record: 'haproxy:haproxy_backend_http_responses_total:percentage:1m',
+          },
+          {
+            expr: |||
               label_replace(haproxy_backend_up{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
                 * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-              "label_app_mintel_com_owner",
-              "satoshi",
-              "label_app_mintel_com_owner",
-              ""
-              )
+                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
             |||,
-            record: 'haproxy:haproxy_backend_up:labeled',
+            record: 'haproxy:haproxy_backend_up:counter',
           },
           {
             expr: |||
-              label_replace(
               label_replace(haproxy_server_up{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
                 * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-              "label_app_mintel_com_owner",
-              "satoshi",
-              "label_app_mintel_com_owner",
-              ""
-              )
+                label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
             |||,
-            record: 'haproxy:haproxy_server_up:labeled',
+            record: 'haproxy:haproxy_server_up:counter',
           },
           {
             expr: |||
-              histogram_quantile(0.95, sum(rate(haproxy:http_backend_response_wait_seconds_bucket:labeled[5m])) by (mintel_com_service, le, label_app_mintel_com_owner))
+              (
+              sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (haproxy:haproxy_server_up:counter)
+              /
+              count by (mintel_com_service, label_app_mintel_com_owner, job, pod) (haproxy:haproxy_server_up:counter)
+              ) * 100
             |||,
-            labels: {
-              quantile: '0.95',
-            },
-            record: 'haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile',
-          },
-          {
-            expr: |||
-              histogram_quantile(0.95, sum(rate(haproxy:http_backend_queue_time_seconds_bucket:labeled[5m])) by (mintel_com_service, le, label_app_mintel_com_owner))
-            |||,
-            labels: {
-              quantile: '0.95',
-            },
-            record: 'haproxy:http_backend_queue_time_seconds_bucket:histogram_quantile',
+            record: 'haproxy:haproxy_server_up:percentage',
           },
           {
             expr: |||
               100 * (
-                sum by (frontend) (haproxy_frontend_current_sessions) 
+                sum by (frontend, job, pod) (haproxy_frontend_current_sessions) 
                 / 
-                sum by (frontend) (haproxy_frontend_limit_sessions)
+                sum by (frontend, job, pod) (haproxy_frontend_limit_sessions)
               )
             |||,
             record: 'haproxy:http_frontend_session_usage:percentage',

--- a/lib/mintel/rules/haproxy-ingress.libsonnet
+++ b/lib/mintel/rules/haproxy-ingress.libsonnet
@@ -9,7 +9,6 @@
               label_replace(haproxy_backend_response_errors_total{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
                 * on(mintel_com_service) group_left(label_app_mintel_com_owner)
                 label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
-              )
             |||,
             record: 'haproxy:haproxy_backend_response_errors_total:counter',
           },
@@ -29,6 +28,7 @@
           },
           {
             expr: |||
+              (
               sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter{code=~"5.."}[1m]))
               /
               sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1598,7 +1598,7 @@ spec:
     - alert: ImageServiceHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: 95th percentile of response times increased to 5s on {{
+        summary: 'HAProxy: 95th percentile of response times is more than 5s on {{
           $labels.mintel_com_service }} backend.'
       expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"}
         > 5
@@ -1609,7 +1609,7 @@ spec:
     - alert: ImageServiceHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: 95th percentile of response times increased to 1s on {{
+        summary: 'HAProxy: 95th percentile of response times is more than 1s on {{
           $labels.mintel_com_service }} backend.'
       expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"}
         > 1
@@ -2053,7 +2053,7 @@ spec:
     - alert: PortalHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: 95th percentile of response times increased to 0.5s on
+        summary: 'HAProxy: 95th percentile of response times is more than 0.5s on
           {{ $labels.mintel_com_service }} backend.'
       expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"}
         > 0.5
@@ -2063,7 +2063,7 @@ spec:
     - alert: PortalHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: 95th percentile of response times increased to 1s on {{
+        summary: 'HAProxy: 95th percentile of response times is more than 1s on {{
           $labels.mintel_com_service }} backend.'
       expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"}
         > 1

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1503,16 +1503,6 @@ spec:
       labels:
         page: "true"
         severity: critical
-    - alert: HAProxyBackendRequestQueued
-      annotations:
-        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendRequestQueued
-        summary: 'HAProxy: Request are queuing up on the {{ $labels.mintel_com_service
-          }} backend'
-      expr: sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_current_queue:labeled)
-        > 10
-      for: 2m
-      labels:
-        severity: warning
     - alert: HAProxyBackendResponseErrors
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendResponseErrors

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -223,7 +223,7 @@ spec:
           label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
       record: haproxy:haproxy_backend_response_errors_total:counter
     - expr: |
-        sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_response_errors_total:counter[1m]))
+        sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_response_errors_total:counter[1m]))
       record: haproxy:haproxy_backend_response_errors_total:rate:1m
     - expr: |
         label_replace(haproxy_backend_http_responses_total{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
@@ -232,9 +232,9 @@ spec:
       record: haproxy:haproxy_backend_http_responses_total:counter
     - expr: |
         (
-        sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter{code=~"5.."}[1m]))
+        sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_http_responses_total:counter{code=~"5.."}[1m]))
         /
-        sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
+        sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
         ) * 100
       record: haproxy:haproxy_backend_http_responses_total:percentage:1m
     - expr: |

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -218,94 +218,44 @@ spec:
   - name: haproxy-ingress.rules
     rules:
     - expr: |
-        label_replace(
-        label_replace(http_backend_response_wait_seconds_bucket{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
-        * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-        "label_app_mintel_com_owner",
-        "satoshi",
-        "label_app_mintel_com_owner",
-        ""
-        )
-      record: haproxy:http_backend_response_wait_seconds_bucket:labeled
-    - expr: |
-        label_replace(
-        label_replace(http_backend_queue_time_seconds_bucket{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
-          * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-        "label_app_mintel_com_owner",
-        "satoshi",
-        "label_app_mintel_com_owner",
-        ""
-        )
-      record: haproxy:http_backend_queue_time_seconds_bucket:labeled
-    - expr: |
-        label_replace(
-        label_replace(haproxy_backend_current_queue{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
-          * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-        "label_app_mintel_com_owner",
-        "satoshi",
-        "label_app_mintel_com_owner",
-        ""
-        )
-      record: haproxy:haproxy_backend_current_queue:labeled
-    - expr: |
-        label_replace(
         label_replace(haproxy_backend_response_errors_total{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
           * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-        "label_app_mintel_com_owner",
-        "satoshi",
-        "label_app_mintel_com_owner",
-        ""
-        )
-      record: haproxy:haproxy_backend_response_errors_total:labeled
+          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:haproxy_backend_response_errors_total:counter
     - expr: |
-        label_replace(
+        sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_response_errors_total:counter[1m]))
+      record: haproxy:haproxy_backend_response_errors_total:rate:1m
+    - expr: |
         label_replace(haproxy_backend_http_responses_total{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
           * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-        "label_app_mintel_com_owner",
-        "satoshi",
-        "label_app_mintel_com_owner",
-        ""
-        )
-      record: haproxy:haproxy_backend_http_responses_total:labeled
+          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:haproxy_backend_http_responses_total:counter
     - expr: |
-        label_replace(
+        (
+        sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter{code=~"5.."}[1m]))
+        /
+        sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
+        ) * 100
+      record: haproxy:haproxy_backend_http_responses_total:percentage:1m
+    - expr: |
         label_replace(haproxy_backend_up{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
           * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-        "label_app_mintel_com_owner",
-        "satoshi",
-        "label_app_mintel_com_owner",
-        ""
-        )
-      record: haproxy:haproxy_backend_up:labeled
+          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:haproxy_backend_up:counter
     - expr: |
-        label_replace(
         label_replace(haproxy_server_up{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
           * on(mintel_com_service) group_left(label_app_mintel_com_owner)
-          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service"),
-        "label_app_mintel_com_owner",
-        "satoshi",
-        "label_app_mintel_com_owner",
-        ""
-        )
-      record: haproxy:haproxy_server_up:labeled
+          label_join(kube_service_labels, "mintel_com_service", "-", "namespace", "service")
+      record: haproxy:haproxy_server_up:counter
     - expr: |
-        histogram_quantile(0.95, sum(rate(haproxy:http_backend_response_wait_seconds_bucket:labeled[5m])) by (mintel_com_service, le, label_app_mintel_com_owner))
-      labels:
-        quantile: "0.95"
-      record: haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile
-    - expr: |
-        histogram_quantile(0.95, sum(rate(haproxy:http_backend_queue_time_seconds_bucket:labeled[5m])) by (mintel_com_service, le, label_app_mintel_com_owner))
-      labels:
-        quantile: "0.95"
-      record: haproxy:http_backend_queue_time_seconds_bucket:histogram_quantile
-    - expr: "100 * (\n  sum by (frontend) (haproxy_frontend_current_sessions) \n  /
-        \n  sum by (frontend) (haproxy_frontend_limit_sessions)\n)\n"
+        (
+        sum by (mintel_com_service, label_app_mintel_com_owner, job, pod) (haproxy:haproxy_server_up:counter)
+        /
+        count by (mintel_com_service, label_app_mintel_com_owner, job, pod) (haproxy:haproxy_server_up:counter)
+        ) * 100
+      record: haproxy:haproxy_server_up:percentage
+    - expr: "100 * (\n  sum by (frontend, job, pod) (haproxy_frontend_current_sessions)
+        \n  / \n  sum by (frontend, job, pod) (haproxy_frontend_limit_sessions)\n)\n"
       record: haproxy:http_frontend_session_usage:percentage
     - expr: |
         label_replace(
@@ -1563,43 +1513,12 @@ spec:
       for: 2m
       labels:
         severity: warning
-    - alert: HAProxyBackendRequestQueued
-      annotations:
-        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendRequestQueued
-        summary: 'HAProxy: Request are queuing up on the {{ $labels.mintel_com_service
-          }} backend'
-      expr: sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_current_queue:labeled)
-        > 100
-      for: 10m
-      labels:
-        page: "true"
-        severity: critical
-    - alert: HAProxyBackendRequestQueuedTime
-      annotations:
-        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendRequestQueuedTime
-        summary: 'HAProxy: Excessive request queue time on the {{ $labels.mintel_com_service
-          }} backend'
-      expr: haproxy:http_backend_queue_time_seconds_bucket:histogram_quantile > 0.3
-      for: 2m
-      labels:
-        severity: warning
-    - alert: HAProxyBackendRequestQueuedTime
-      annotations:
-        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendRequestQueuedTime
-        summary: 'HAProxy: Excessive request queue time on the {{ $labels.mintel_com_service
-          }} backend'
-      expr: haproxy:http_backend_queue_time_seconds_bucket:histogram_quantile > 0.5
-      for: 10m
-      labels:
-        page: "true"
-        severity: critical
     - alert: HAProxyBackendResponseErrors
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendResponseErrors
         summary: 'HAProxy: Response errors detected on {{ $labels.mintel_com_service
           }} backend'
-      expr: sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_response_errors_total:labeled[1m]))
-        > 1
+      expr: haproxy:haproxy_backend_response_errors_total:rate:1m > 1
       for: 2m
       labels:
         severity: warning
@@ -1608,8 +1527,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendResponseErrors
         summary: 'HAProxy: Response errors detected on {{ $labels.mintel_com_service
           }} backend'
-      expr: sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_response_errors_total:labeled[1m]))
-        > 10
+      expr: haproxy:haproxy_backend_response_errors_total:rate:1m > 10
       for: 10m
       labels:
         page: "false"
@@ -1619,12 +1537,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendResponseErrors5xx
         summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service
           }} service'
-      expr: |
-        (
-        sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled{code=~"5.."}[1m]))
-        /
-        sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled[1m]))
-        ) * 100 > 1
+      expr: haproxy:haproxy_backend_http_responses_total:percentage:1m > 1
       for: 5m
       labels:
         severity: warning
@@ -1633,12 +1546,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendResponseErrors5xx
         summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service
           }} service'
-      expr: |
-        (
-        sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled{code=~"5.."}[1m]))
-        /
-        sum by (mintel_com_service, label_app_mintel_com_owner) (rate(haproxy:haproxy_backend_http_responses_total:labeled[1m]))
-        ) * 100 > 10
+      expr: haproxy:haproxy_backend_http_responses_total:percentage:1m > 10
       for: 10m
       labels:
         page: "true"
@@ -1648,7 +1556,7 @@ spec:
         description: 'HAProxy: {{ $labels.mintel_com_service }} backend has been down
           for at least 1m on all Ingress pods'
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendDown
-      expr: sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_up:labeled)
+      expr: sum by (mintel_com_service, label_app_mintel_com_owner) (haproxy:haproxy_backend_up:counter)
         == 0
       for: 5m
       labels:
@@ -1659,9 +1567,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyServerInBackendUpPercentageLow
         summary: 'HAProxy: The percentage of server up in backend for {{ $labels.mintel_com_service
           }} service is low on ingress {{ $labels.pod }} : {{ $value }}%'
-      expr: "(\nsum by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)\n/\ncount
-        by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)\n)
-        * 100 < 75 \n"
+      expr: haproxy:haproxy_server_up:percentage < 75
       for: 5m
       labels:
         severity: warning
@@ -1670,12 +1576,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyServerInBackendUpPercentageLow
         summary: 'HAProxy: The percentage of server up in backend for {{ $labels.mintel_com_service
           }} service is low on ingress {{ $labels.pod }} : {{ $value }}%'
-      expr: |
-        (
-        sum by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)
-        /
-        count by (mintel_com_service, label_app_mintel_com_owner, pod) (haproxy:haproxy_server_up:labeled)
-        ) * 100 < 50
+      expr: haproxy:haproxy_server_up:percentage < 50
       for: 5m
       labels:
         page: "false"
@@ -1697,22 +1598,22 @@ spec:
     - alert: ImageServiceHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service
-          }} backend.'
-      expr: |
-        haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="moat", mintel_com_service=~".*image-service.*"} > 5
-      for: 2m
+        summary: 'HAProxy: 95th percentile of response times increased to 5s on {{
+          $labels.mintel_com_service }} backend.'
+      expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"}
+        > 5
+      for: 5m
       labels:
         page: "true"
         severity: critical
     - alert: ImageServiceHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service
-          }} backend.'
-      expr: |
-        haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="moat", mintel_com_service=~".*image-service.*"} > 1
-      for: 5m
+        summary: 'HAProxy: 95th percentile of response times increased to 1s on {{
+          $labels.mintel_com_service }} backend.'
+      expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*image-service.*"}
+        > 1
+      for: 10m
       labels:
         severity: warning
     - alert: ImageServiceAuthIssues
@@ -2152,21 +2053,21 @@ spec:
     - alert: PortalHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service
-          }} backend.'
-      expr: |
-        haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="portal",mintel_com_service=~".*-portal-web"} > 0.5
-      for: 5m
+        summary: 'HAProxy: 95th percentile of response times increased to 0.5s on
+          {{ $labels.mintel_com_service }} backend.'
+      expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"}
+        > 0.5
+      for: 10m
       labels:
         severity: warning
     - alert: PortalHAProxyBackendResponseTime
       annotations:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#haproxybackendresponsetime
-        summary: 'HAProxy: Average response times increased on {{ $labels.mintel_com_service
-          }} backend.'
-      expr: |
-        haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile{label_app_mintel_com_owner="portal",mintel_com_service=~".*-portal-web"} > 1
-      for: 30m
+        summary: 'HAProxy: 95th percentile of response times increased to 1s on {{
+          $labels.mintel_com_service }} backend.'
+      expr: haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=~".*portal-web"}
+        > 1
+      for: 5m
       labels:
         page: "true"
         severity: critical


### PR DESCRIPTION
### Recording rules Haproxy
* `haproxy:http_backend_response_wait_seconds_bucket:labeled` - removed , not used\
  This was `A histogram of the time spent waiting on the backend response (Tr)` which is not what we used it for anyway. We can use `http_backend_request_duration_seconds` to alert on the whole duration of the request 
* `haproxy:http_backend_queue_time_seconds_bucket:labeled` - removed, not used\
  we do not need to alert and graph on queues. We can do that in the logs if we need to 
* `haproxy:haproxy_backend_current_queue:labeled` - removed, not used\
  we do not need to alert and graph on queues. We can do that in the logs if we need to
* `haproxy:http_backend_response_wait_seconds_bucket:histogram_quantile` - removed, not used
* `haproxy:http_backend_queue_time_seconds_bucket:histogram_quantile` - removed, not used
* remove outer label_replace for `label_app_mintel_com_owner` since we already have an ELSE in alertmanager to set that 
* rename all left metrics from `.*:labeled` to `.*:(counter|percentage|rate|...)`

### Alerting rules Haproxy
* `HAProxyBackendRequestQueued` - removed , we already monitor and alert on the Response time for each service 
* `HAProxyBackendRequestQueuedTime` - removed , we already monitor and alert on the Response time for each service 
* `HAProxyBackendResponseErrors` - change to use pre-recorded metric
* `HAProxyBackendResponseErrors5xx` - change to use pre-recorded metric
* `HAProxyBackendDown` - change of metric name 
* `HAProxyServerInBackendUpPercentageLow` - change to use pre-recorded metric


### Image Service alerting
* `ImageServiceHAProxyBackendResponseTime` - Change to use the same metric we use in the dashboard
* Change Warning and Critical time threshold as discussed with nick

### Portal alerting
* `PortalHAProxyBackendResponseTime` - Change to use same metric we use in dashboard and fix the selector so it actually match
* Change Warning and Critical time threshold as discussed with nick

### Dashboard 
* Little fix for the PodResources row of widgets used in prometheus performance dashboard
  * Rate instead of irate fo 1m interval
  * default to 5m for the average one rather than "$__interval"