### PR TITLE
Rename recording rule for haproxy-backend error rate

### DIFF
--- a/lib/mintel/alerts/haproxy-ingress.libsonnet
+++ b/lib/mintel/alerts/haproxy-ingress.libsonnet
@@ -122,7 +122,7 @@
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendResponseErrors5xx' % $._config,
               summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service }} service',
             },
-            expr: 'haproxy:haproxy_backend_http_responses_total:percentage:1m > 1',
+            expr: 'haproxy:haproxy_backend_http_error_rate:percentage:1m > 1',
             'for': '5m',
             labels: {
               severity: 'warning',
@@ -134,7 +134,7 @@
               runbook_url: '%(runBookBaseURL)s/core/HAProxy.md#HAProxyBackendResponseErrors5xx' % $._config,
               summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service }} service',
             },
-            expr: 'haproxy:haproxy_backend_http_responses_total:percentage:1m > 10',
+            expr: 'haproxy:haproxy_backend_http_error_rate:percentage:1m > 10',
             'for': '10m',
             labels: {
               severity: 'critical',

--- a/lib/mintel/rules/haproxy-ingress.libsonnet
+++ b/lib/mintel/rules/haproxy-ingress.libsonnet
@@ -34,7 +34,7 @@
               sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
               ) * 100
             |||,
-            record: 'haproxy:haproxy_backend_http_responses_total:percentage:1m',
+            record: 'haproxy:haproxy_backend_http_error_rate:percentage:1m',
           },
           {
             expr: |||

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -236,7 +236,7 @@ spec:
         /
         sum by (mintel_com_service, label_app_mintel_com_owner, job) (rate(haproxy:haproxy_backend_http_responses_total:counter[1m]))
         ) * 100
-      record: haproxy:haproxy_backend_http_responses_total:percentage:1m
+      record: haproxy:haproxy_backend_http_error_rate:percentage:1m
     - expr: |
         label_replace(haproxy_backend_up{backend!~"(error|stats|.*default-backend)"}, "mintel_com_service", "$1", "backend", "(.*)-\\d+$")
           * on(mintel_com_service) group_left(label_app_mintel_com_owner)
@@ -1538,7 +1538,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendResponseErrors5xx
         summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service
           }} service'
-      expr: haproxy:haproxy_backend_http_responses_total:percentage:1m > 1
+      expr: haproxy:haproxy_backend_http_error_rate:percentage:1m > 1
       for: 5m
       labels:
         severity: warning
@@ -1547,7 +1547,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/HAProxy.md#HAProxyBackendResponseErrors5xx
         summary: 'HAProxy: Increased number of 5xx responses on {{ $labels.mintel_com_service
           }} service'
-      expr: haproxy:haproxy_backend_http_responses_total:percentage:1m > 10
+      expr: haproxy:haproxy_backend_http_error_rate:percentage:1m > 10
       for: 10m
       labels:
         page: "true"


### PR DESCRIPTION
Rename it, since it's an error-rate.