### PR TITLE
Define un-defined `namespace` var locally (mostly for local-dev).

### DIFF
--- a/lib/mintel/config.libsonnet
+++ b/lib/mintel/config.libsonnet
@@ -1,6 +1,11 @@
 {
   _config+:: {
     local this = self,
+
+    // Set namespace here to allow jsonnet rendering from this directory.
+    // Note, this will get overwritten by the main config (default is 'monitoring)'...
+    namespace: 'monitoring',
+
     // Selectors are inserted between {} in Prometheus queries.
     namespaceSelector: null,
     prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',


### PR DESCRIPTION
Maintains existing functionality of being able to render mintel-specific jsonnet (not from the top-level).