### PR TITLE
Ensure we set a min interval on the flux-daemon-metrics dashboard

### DIFF
--- a/dashboards/mintel/flux/flux-metrics-dashboard.json
+++ b/dashboards/mintel/flux/flux-metrics-dashboard.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": 10475,
   "graphTooltip": 0,
-  "id": 170,
-  "iteration": 1587988044941,
+  "id": 65,
+  "iteration": 1591267387662,
   "links": [],
   "panels": [
     {
@@ -36,6 +36,7 @@
       },
       "hiddenSeries": false,
       "id": 12,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -132,6 +133,7 @@
       },
       "hiddenSeries": false,
       "id": 4,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -228,6 +230,7 @@
       },
       "hiddenSeries": false,
       "id": 2,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -324,6 +327,7 @@
       },
       "hiddenSeries": false,
       "id": 8,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -414,6 +418,7 @@
       },
       "hiddenSeries": false,
       "id": 6,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -521,6 +526,7 @@
       },
       "hiddenSeries": false,
       "id": 16,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -613,6 +619,7 @@
       },
       "hiddenSeries": false,
       "id": 10,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -704,6 +711,7 @@
       },
       "hiddenSeries": false,
       "id": 14,
+      "interval": "2m",
       "legend": {
         "avg": false,
         "current": false,
@@ -794,7 +802,6 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
           "text": "flux-apps",
           "value": "flux-apps"
         },
@@ -851,5 +858,5 @@
   "timezone": "",
   "title": "Flux Daemon Metrics",
   "uid": "vJMuruVWkx",
-  "version": 4
+  "version": 1
 }


### PR DESCRIPTION
Without this, on smaller timeframes (3hrs at least), we end up passing through `15s` time intervals to prometheus which does not work.

This ensures a sensible min value. 

Note that `5m` smooths the graph too much and hides useful level of detail, so using `2m`