### PR TITLE
Feat/add omni dashboards

### DIFF
--- a/dashboards/rendered/image-service-overview.json
+++ b/dashboards/rendered/image-service-overview.json
@@ -556,7 +556,7 @@
                "description": "",
                "fill": 0,
                "gridPos": {
-                  "h": 200,
+                  "h": 10,
                   "w": 12,
                   "x": 0,
                   "y": 1000
@@ -645,7 +645,7 @@
                "description": "",
                "fill": 0,
                "gridPos": {
-                  "h": 200,
+                  "h": 10,
                   "w": 12,
                   "x": 12,
                   "y": 1000
@@ -680,7 +680,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$deployment-.*\", container=\"main\"}) by (pod)\n",
+                     "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$deployment.*\", container=\"main\"}\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/dashboards/rendered/image-service-overview.json
+++ b/dashboards/rendered/image-service-overview.json
@@ -102,7 +102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) /(kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) /(kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
+                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) / (kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) / (kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -385,7 +385,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      http_request_duration_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "expr": "mintel:http_request_duration_seconds_quantile:95{service=\"$service\", analytics_type=~\"$analytics_type\"}\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
@@ -393,7 +393,7 @@
                      "refId": "A"
                   },
                   {
-                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "expr": "mintel:http_request_duration_seconds_quantile:75{service=\"$service\", analytics_type=~\"$analytics_type\"}\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
@@ -401,7 +401,7 @@
                      "refId": "B"
                   },
                   {
-                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "expr": "mintel:http_request_duration_seconds_quantile:50{service=\"$service\", analytics_type=~\"$analytics_type\"}\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -385,7 +385,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      http_request_duration_seconds_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      http_request_duration_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
@@ -393,7 +393,7 @@
                      "refId": "A"
                   },
                   {
-                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
@@ -401,7 +401,7 @@
                      "refId": "B"
                   },
                   {
-                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,
@@ -703,6 +703,29 @@
             "options": [ ],
             "query": "label_values(kube_service_labels{namespace=\"$namespace\"}, label_app_kubernetes_io_instance)",
             "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": ".*",
+            "current": {
+               "text": "",
+               "value": ""
+            },
+            "datasource": "Prometheus",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Analytics Type",
+            "multi": true,
+            "name": "analytics_type",
+            "options": [ ],
+            "query": "label_values(http_request_duration_seconds_count{namespace=\"omni\"}, analytics_type)",
+            "refresh": 2,
             "regex": "",
             "sort": 0,
             "tagValuesQuery": "",

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -47,7 +47,7 @@
          "targetBlank": true,
          "title": "Workload",
          "type": "link",
-         "url": "/d/fixme"
+         "url": "/d/a164a7f0339f99e89cea5cb47e9be617"
       }
    ],
    "refresh": "",
@@ -563,6 +563,111 @@
                      "show": false
                   }
                ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Percentile Latency For Analytics ElasticSearch Responses",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 0
+               },
+               "height": 300,
+               "id": 7,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "connected",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 12,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p95 {{ service }}/{{ analytics_type }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p75 {{ service }}/{{ analytics_type }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p50 {{ service }}/{{ analytics_type }}",
+                     "refId": "C"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "ElasticSearch Response Latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": "Time",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
             }
          ],
          "repeat": null,
@@ -593,7 +698,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 7,
+               "id": 8,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -682,7 +787,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 8,
+               "id": 9,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -1,0 +1,439 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [
+         {
+            "datasource": "Elasticsearch-fluxcloud",
+            "enable": true,
+            "hide": false,
+            "iconColor": "#96D98D",
+            "name": "flux-release",
+            "query": "message.EventType:release AND message.Namespaces: \"$namespace\"",
+            "showIn": 0,
+            "tags": [ ],
+            "tagsField": "message.Tags",
+            "textField": "message.Body",
+            "type": "tags"
+         },
+         {
+            "datasource": "Elasticsearch-fluxcloud",
+            "enable": true,
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "name": "flux-autorelease",
+            "query": "message.EventType:autorelease AND message.Namespaces: \"$namespace\"",
+            "showIn": 0,
+            "tags": [ ],
+            "tagsField": "message.Tags",
+            "textField": "message.Body",
+            "type": "tags"
+         }
+      ]
+   },
+   "description": "Provides an overview of the Omni Analytics Stack",
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 1,
+   "hideControls": false,
+   "id": null,
+   "links": [
+      {
+         "asDropdown": false,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": "",
+         "targetBlank": true,
+         "title": "Workload",
+         "type": "link",
+         "url": "/d/fixme"
+      }
+   ],
+   "refresh": "",
+   "rows": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "height": 5,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Percentage of instances up (by workload)",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 0,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 2,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) /(kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) /(kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [
+                  {
+                     "colorMode": "critical",
+                     "fill": true,
+                     "line": true,
+                     "op": "lt",
+                     "value": 50
+                  }
+               ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Workloads Status",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percent",
+                     "label": "",
+                     "logBase": 1,
+                     "max": 100,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "cacheTimeout": null,
+               "colorBackground": true,
+               "colorValue": false,
+               "colors": [
+                  "#299c46",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#d44a3a"
+               ],
+               "datasource": "$ds",
+               "description": "Requests per second (all http-status)",
+               "format": "rps",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 2,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 3,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": null,
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 4,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": true,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": true
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "sum(\n  rate(\n    haproxy:haproxy_backend_http_responses_total:counter{backend=~\"$namespace-.*$service-[0-9].*\"}[$__interval]))\n",
+                     "format": "time_series",
+                     "instant": false,
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "",
+               "title": "Incoming Request Volume",
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "current"
+            },
+            {
+               "cacheTimeout": null,
+               "colorBackground": true,
+               "colorValue": false,
+               "colors": [
+                  "#d44a3a",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#299c46"
+               ],
+               "datasource": "$ds",
+               "description": "Percentage of successful (non http-5xx) requests",
+               "format": "percent",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 4,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 4,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": null,
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 4,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": true,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": true
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "100 - haproxy:haproxy_backend_http_error_rate:percentage:1m{mintel_com_service=\"$namespace-$service\"}\n",
+                     "format": "time_series",
+                     "instant": false,
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "99,95",
+               "title": "Incoming Success Rate",
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "current"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Overview",
+         "titleSize": "h6",
+         "type": "row"
+      }
+   ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "mintel",
+      "omni"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "Prometheus",
+               "value": "Prometheus"
+            },
+            "hide": 2,
+            "label": null,
+            "name": "ds",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": {
+               "text": "omni",
+               "value": "omni"
+            },
+            "datasource": "Prometheus",
+            "hide": 2,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [ ],
+            "query": "label_values(kube_pod_container_info,namespace)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "Prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Service",
+            "multi": false,
+            "name": "service",
+            "options": [ ],
+            "query": "label_values(kube_service_labels{namespace=\"$namespace\"}, label_app_kubernetes_io_instance)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Mintel /  Omni Analytics",
+   "uid": "d3ee911e9ec93c9452af29ab7166ee72",
+   "version": 0
+}

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -338,6 +338,125 @@
       {
          "collapse": false,
          "collapsed": false,
+         "height": 5,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Percentile Latency For Analytics API Server",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "height": 300,
+               "id": 5,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "connected",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 12,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      http_request_duration_seconds_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p95 {{ service }}/{{ analytics_type }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p75 {{ service }}/{{ analytics_type }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    http_request_duration_seconds_bucket{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p50 {{ service }}/{{ analytics_type }}",
+                     "refId": "C"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "API Server Latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": "Time",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Analytics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
          "panels": [
             {
                "aliasColors": { },
@@ -355,7 +474,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 5,
+               "id": 6,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -444,7 +563,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 6,
+               "id": 7,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -563,111 +563,6 @@
                      "show": false
                   }
                ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$ds",
-               "decimals": 2,
-               "description": "Percentile Latency For Analytics ElasticSearch Responses",
-               "fill": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "height": 300,
-               "id": 7,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": false,
-                  "show": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "nullPointMode": "connected",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
-                     "format": "time_series",
-                     "interval": "1m",
-                     "intervalFactor": 2,
-                     "legendFormat": "p95 {{ service }}/{{ analytics_type }}",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
-                     "format": "time_series",
-                     "interval": "1m",
-                     "intervalFactor": 2,
-                     "legendFormat": "p75 {{ service }}/{{ analytics_type }}",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
-                     "format": "time_series",
-                     "interval": "1m",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{ service }}/{{ analytics_type }}",
-                     "refId": "C"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "ElasticSearch Response Latency",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": "Time",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": 1,
-                     "min": 0,
-                     "show": false
-                  }
-               ]
             }
          ],
          "repeat": null,
@@ -698,7 +593,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 8,
+               "id": 7,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -787,7 +682,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 9,
+               "id": 8,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -450,7 +450,126 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Analytics",
+         "title": "API Service",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "height": 5,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Percentile Latency For Analytics ElasticSearch Responses",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "height": 300,
+               "id": 6,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "connected",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 12,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.95,\n  sum(\n    rate(\n      omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p95 {{ service }}/{{ analytics_type }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.75,\nsum(\n  rate(\n    omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p75 {{ service }}/{{ analytics_type }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.50,\nsum(\n  rate(\n    omni_analytics_es_request_processing_seconds_bucket{namespace=\"$namespace\", analytics_type=~\"$analytics_type\", service=\"$service\"}[$__interval]))\nby (service, analytics_type, le))\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p50 {{ service }}/{{ analytics_type }}",
+                     "refId": "C"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "ElasticSearch Response Latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": "Time",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "ES Responses",
          "titleSize": "h6",
          "type": "row"
       },
@@ -474,7 +593,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 6,
+               "id": 7,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -563,7 +682,7 @@
                   "y": 1000
                },
                "height": 200,
-               "id": 7,
+               "id": 8,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -334,6 +334,197 @@
          "title": "Overview",
          "titleSize": "h6",
          "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 5,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$service.*\", container=\"main\"}[5m])) by (pod)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ pod }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Per Instance CPU",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "CPU Usage",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 6,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service.*\", container=\"main\"}\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ pod }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Per Instance Memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Memory Usage",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Resources",
+         "titleSize": "h6",
+         "type": "row"
       }
    ],
    "schemaVersion": 14,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -102,7 +102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) /(kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) /(kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
+                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) / (kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) / (kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -218,7 +218,7 @@
                "tableColumn": "",
                "targets": [
                   {
-                     "expr": "sum(\n  rate(\n    haproxy:haproxy_backend_http_responses_total:counter{backend=~\"$namespace-.*$service-[0-9].*\"}[$__interval]))\n",
+                     "expr": "sum(\n  rate(\n    http_request_duration_seconds_count{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\n",
                      "format": "time_series",
                      "instant": false,
                      "interval": "1m",
@@ -304,7 +304,7 @@
                "tableColumn": "",
                "targets": [
                   {
-                     "expr": "100 - haproxy:haproxy_backend_http_error_rate:percentage:1m{mintel_com_service=\"$namespace-$service\"}\n",
+                     "expr": "100 - (\n  sum by (service, app_mintel_com_owner)\n    (\n      rate(http_request_duration_seconds_count{namespace=\"$namespace\", service=\"$service\", status_code=~\"5..\"}[$__interval])\n          or 0 * up{namespace=\"$namespace\", service=\"$service\"}\n    )\n\n  /\n  sum by (service, app_mintel_com_owner)\n    (\n      rate(http_request_duration_seconds_count{namespace=\"$namespace\", service=\"$service\"}[$__interval])\n        or 0 * up{namespace=\"$namespace\", service=\"$service\"}\n    )\n) * 100\n",
                      "format": "time_series",
                      "instant": false,
                      "interval": "1m",

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -218,7 +218,7 @@
                "tableColumn": "",
                "targets": [
                   {
-                     "expr": "sum(\n  rate(\n    http_request_duration_seconds_count{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\n",
+                     "expr": "sum(\n  rate(\n    http_requests_total{namespace=\"$namespace\", service=\"$service\"}[$__interval]))\n",
                      "format": "time_series",
                      "instant": false,
                      "interval": "1m",
@@ -304,7 +304,7 @@
                "tableColumn": "",
                "targets": [
                   {
-                     "expr": "100 - (\n  sum by (service, app_mintel_com_owner)\n    (\n      rate(http_request_duration_seconds_count{namespace=\"$namespace\", service=\"$service\", status_code=~\"5..\"}[$__interval])\n          or 0 * up{namespace=\"$namespace\", service=\"$service\"}\n    )\n\n  /\n  sum by (service, app_mintel_com_owner)\n    (\n      rate(http_request_duration_seconds_count{namespace=\"$namespace\", service=\"$service\"}[$__interval])\n        or 0 * up{namespace=\"$namespace\", service=\"$service\"}\n    )\n) * 100\n",
+                     "expr": "100 - mintel:http_error_rate:percentage:1m{service=\"$service\"}\n",
                      "format": "time_series",
                      "instant": false,
                      "interval": "1m",

--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -347,7 +347,7 @@
                "dashes": false,
                "datasource": "$ds",
                "decimals": 2,
-               "description": "Percentile Latency For Analytics API Server",
+               "description": "Percentile Latency For Analytics API Service",
                "fill": 0,
                "gridPos": {
                   "h": 10,
@@ -412,7 +412,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "API Server Latency",
+               "title": "API Service Latency",
                "tooltip": {
                   "shared": true,
                   "sort": 2,

--- a/dashboards/rendered/omni-web-overview.json
+++ b/dashboards/rendered/omni-web-overview.json
@@ -47,7 +47,7 @@
          "targetBlank": true,
          "title": "Workload",
          "type": "link",
-         "url": "/d/fixme"
+         "url": "/d/a164a7f0339f99e89cea5cb47e9be617"
       }
    ],
    "refresh": "",

--- a/dashboards/rendered/omni-web-overview.json
+++ b/dashboards/rendered/omni-web-overview.json
@@ -768,7 +768,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service-.*\", container=\"main\"}\n",
+                     "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service.*\", container=\"main\"}\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/dashboards/rendered/omni-web-overview.json
+++ b/dashboards/rendered/omni-web-overview.json
@@ -1,0 +1,2636 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [
+         {
+            "datasource": "Elasticsearch-fluxcloud",
+            "enable": true,
+            "hide": false,
+            "iconColor": "#96D98D",
+            "name": "flux-release",
+            "query": "message.EventType:release AND message.Namespaces: \"$namespace\"",
+            "showIn": 0,
+            "tags": [ ],
+            "tagsField": "message.Tags",
+            "textField": "message.Body",
+            "type": "tags"
+         },
+         {
+            "datasource": "Elasticsearch-fluxcloud",
+            "enable": true,
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "name": "flux-autorelease",
+            "query": "message.EventType:autorelease AND message.Namespaces: \"$namespace\"",
+            "showIn": 0,
+            "tags": [ ],
+            "tagsField": "message.Tags",
+            "textField": "message.Body",
+            "type": "tags"
+         }
+      ]
+   },
+   "description": "Provides an overview of the Omni Web Stack",
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 1,
+   "hideControls": false,
+   "id": null,
+   "links": [
+      {
+         "asDropdown": false,
+         "icon": "external link",
+         "includeVars": true,
+         "keepTime": true,
+         "tags": "",
+         "targetBlank": true,
+         "title": "Workload",
+         "type": "link",
+         "url": "/d/fixme"
+      }
+   ],
+   "refresh": "",
+   "rows": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "height": 5,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Percentage of instances up (by workload)",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 0,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 2,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) /(kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) /(kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [
+                  {
+                     "colorMode": "critical",
+                     "fill": true,
+                     "line": true,
+                     "op": "lt",
+                     "value": 50
+                  }
+               ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Workloads Status",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percent",
+                     "label": "",
+                     "logBase": 1,
+                     "max": 100,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "cacheTimeout": null,
+               "colorBackground": true,
+               "colorValue": false,
+               "colors": [
+                  "#299c46",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#d44a3a"
+               ],
+               "datasource": "$ds",
+               "description": "Requests per second (all http-status)",
+               "format": "rps",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 2,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 3,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": null,
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 4,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": true,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": true
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "sum(\n  rate(\n    haproxy:haproxy_backend_http_responses_total:counter{backend=~\"$namespace-.*$service-[0-9].*\"}[$__interval]))\n",
+                     "format": "time_series",
+                     "instant": false,
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "",
+               "title": "Incoming Request Volume",
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "current"
+            },
+            {
+               "cacheTimeout": null,
+               "colorBackground": true,
+               "colorValue": false,
+               "colors": [
+                  "#d44a3a",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#299c46"
+               ],
+               "datasource": "$ds",
+               "description": "Percentage of successful (non http-5xx) requests",
+               "format": "percent",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 4,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 4,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": null,
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 4,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": true,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": true
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "100 - haproxy:haproxy_backend_http_error_rate:percentage:1m{mintel_com_service=\"$namespace-$service\"}\n",
+                     "format": "time_series",
+                     "instant": false,
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "99,95",
+               "title": "Incoming Success Rate",
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "current"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Overview",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Percentile Latency from HAProxy Ingress",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 0,
+                  "y": 1000
+               },
+               "height": 300,
+               "id": 5,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "connected",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "haproxy:http_backend_request_seconds_quantile:95{mintel_com_service=\"$namespace-$service\"}\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p95 {{ backend }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "haproxy:http_backend_request_seconds_quantile:75{mintel_com_service=\"$namespace-$service\"}\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p75 {{ backend }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "haproxy:http_backend_request_seconds_quantile:50{mintel_com_service=\"$namespace-$service\"}\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "p50 {{ backend }}",
+                     "refId": "C"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "HAProxy Latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": "Time",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "HTTP Responses from HAProxy Ingress for backend $service",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 2,
+                  "y": 1000
+               },
+               "height": 300,
+               "id": 6,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(\n  rate(\n    haproxy:haproxy_backend_http_responses_total:counter{backend=~\"$namespace-.*$service-[0-9].*\"}[$__interval]\n  )\n) by (code)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ code }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "HAProxy Responses",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Num Responses",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 4,
+                  "y": 1000
+               },
+               "height": 300,
+               "id": 7,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(\n   irate(\n     django_http_requests_total_by_view_transport_method_total{namespace=~\"$namespace\", service=\"$service\"}[5m]))\n by(method, view)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ method }}/{{ view }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "App Requests by Method/View",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Num Requests",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Request / Response",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 8,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$service.*\", container=\"main\"}[5m])) by (pod)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ pod }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Per Instance CPU",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "CPU Usage",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 9,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service-.*\", container=\"main\"}\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ pod }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Per Instance Memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Memory Usage",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Resources",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1000
+               },
+               "height": 200,
+               "id": 10,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 12,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(django_db_execute_total{namespace=~\"$namespace\", service=\"$service\"}[1m])) by (vendor)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ vendor }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "DB Operations",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Num Operations",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Database",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "panels": [
+            {
+               "cacheTimeout": null,
+               "colorBackground": false,
+               "colorValue": false,
+               "colors": [
+                  "#299c46",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#d44a3a"
+               ],
+               "datasource": "$ds",
+               "description": "Number of Celery workers up",
+               "format": "none",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 0,
+                  "y": 1001
+               },
+               "height": 200,
+               "id": 11,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": null,
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 2,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": true,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": true
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "sum(avg_over_time(celery_workers{namespace=\"$namespace\"}[$__interval]))\n",
+                     "format": "time_series",
+                     "instant": false,
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "",
+               "title": "Num Workers",
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "current"
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 2,
+                  "x": 2,
+                  "y": 1001
+               },
+               "height": 200,
+               "id": 12,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": true,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(\n  rate(\n    celery_tasks_total{namespace=\"$namespace\"}[10m]))\nby (name, state)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ name }} / {{ state }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Celery Events",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Num Events",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Celery",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1002
+               },
+               "height": 200,
+               "id": 13,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(avg_over_time(redis_connected_clients{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Connected Clients",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Clients",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Blocked clients are waiting for a state change event using commands such as BLPOP. Blocked clients are not a sign of an issue on their own.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1002
+               },
+               "height": 200,
+               "id": 14,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(avg_over_time(redis_blocked_clients{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Blocked Clients",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Blocked Clients",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1012
+               },
+               "height": 200,
+               "id": 15,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_connections_received_total{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Connections Received",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Connections",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1002
+               },
+               "height": 200,
+               "id": 16,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_commands_total{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 1,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Operation Rate",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Operations/sec",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1002
+               },
+               "height": 200,
+               "id": 17,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_net_output_bytes_total{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Redis Network Out",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "Bps",
+                     "label": "",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1012
+               },
+               "height": 200,
+               "id": 18,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_net_input_bytes_total{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Redis Network In",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "Bps",
+                     "label": "",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1012
+               },
+               "height": 200,
+               "id": 19,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(changes(redis_slowlog_last_id{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 10,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Slowlog Events",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Events",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1022
+               },
+               "height": 200,
+               "id": 20,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_commands_total{service=~\"$service.*\"}[$__interval])) by (cmd)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ cmd }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Operation Rate per Command",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Operations/sec",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1022
+               },
+               "height": 200,
+               "id": 21,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "connected",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_commands_duration_seconds_total{service=~\"$service.*\"}[$__interval])) by (cmd)\n/\nsum(rate(redis_commands_total{service=~\"$service.*\"}[$__interval])) by (cmd)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ cmd }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Average Operation Latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "ms",
+                     "label": "Duration",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1032
+               },
+               "height": 200,
+               "id": 22,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": false,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "connected",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_commands_duration_seconds_total{service=~\"$service.*\"}[$__interval])) by (cmd)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ cmd }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total Operation Latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "ms",
+                     "label": "Duration",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1002
+               },
+               "height": 200,
+               "id": 23,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "max_over_time(redis_memory_used_bytes{service=~\"$service.*\"}[$__interval])\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory Used",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1002
+               },
+               "height": 200,
+               "id": 24,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_memory_used_bytes{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory Used Rate of Change",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "Bps",
+                     "label": "Bytes/sec",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "Depending on the memory allocator used, Redis may not return memory to the operating system at the same rate that applications release keys. RSS indicates the operating systems perspective of Redis memory usage. So, even if usage is low, if RSS is high, the OOM killer may terminate the Redis process",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1012
+               },
+               "height": 200,
+               "id": 25,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "max_over_time(redis_memory_used_rss_bytes{service=~\"$service.*\"}[$__interval])\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Redis RSS Usage",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "The fragmentation ratio in Redis should ideally be around 1.0 and generally below 1.5. The higher the value, the more wasted memory.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1012
+               },
+               "height": 200,
+               "id": 26,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "redis_memory_used_rss_bytes{service=~\"$service.*\"} / redis_memory_used_bytes{service=~\"$service.*\"}\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory Fragmentation",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 0,
+                  "y": 1022
+               },
+               "height": 200,
+               "id": 27,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_expired_keys_total{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Expired Keys",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Keys",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$ds",
+               "decimals": 2,
+               "description": "",
+               "fill": 0,
+               "gridPos": {
+                  "h": 10,
+                  "w": 12,
+                  "x": 12,
+                  "y": 1022
+               },
+               "height": 200,
+               "id": 28,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 2,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(redis_db_keys{service=~\"$service.*\"}[$__interval])) by (service)\n",
+                     "format": "time_series",
+                     "interval": "1m",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ service }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Keys Rate of Change",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": "Keys/sec",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": 1,
+                     "min": 0,
+                     "show": false
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Redis",
+         "titleSize": "h6",
+         "type": "row"
+      }
+   ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "mintel",
+      "omni"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "Prometheus",
+               "value": "Prometheus"
+            },
+            "hide": 2,
+            "label": null,
+            "name": "ds",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": {
+               "text": "omni",
+               "value": "omni"
+            },
+            "datasource": "Prometheus",
+            "hide": 2,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [ ],
+            "query": "label_values(kube_pod_container_info,namespace)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "Prometheus",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Service",
+            "multi": false,
+            "name": "service",
+            "options": [ ],
+            "query": "label_values(kube_service_labels{namespace=\"$namespace\"}, label_app_kubernetes_io_instance)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Mintel /  Omni Web",
+   "uid": "ae79eb1d0f5c628dd450d1e8367f6735",
+   "version": 0
+}

--- a/dashboards/rendered/omni-web-overview.json
+++ b/dashboards/rendered/omni-web-overview.json
@@ -102,7 +102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) /(kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) /(kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
+                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) / (kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) / (kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/dashboards/rendered/portal-overview.json
+++ b/dashboards/rendered/portal-overview.json
@@ -768,7 +768,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service-.*\", container=\"main\"}\n",
+                     "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$service.*\", container=\"main\"}\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/dashboards/rendered/portal-overview.json
+++ b/dashboards/rendered/portal-overview.json
@@ -102,7 +102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) /(kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) /(kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
+                     "expr": "sum by (deployment, statefulset)\n  (\n    100 * (kube_deployment_status_replicas_available{namespace=~\"$namespace\"}) / (kube_deployment_spec_replicas{namespace=~\"$namespace\"})\n    or\n    100 * (kube_statefulset_status_replicas_ready{namespace=~\"$namespace\"}) / (kube_statefulset_status_replicas{namespace=~\"$namespace\"})\n  )\n",
                      "format": "time_series",
                      "interval": "1m",
                      "intervalFactor": 2,

--- a/lib/mintel/alerts/cert-manager.libsonnet
+++ b/lib/mintel/alerts/cert-manager.libsonnet
@@ -1,0 +1,51 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'cert-manager.alerts',
+        rules: [
+          {
+            alert: 'CertManagerCertificateExpireSoon',
+            annotations: {
+              description: 'Cert Manager managed certificate for {{ $labels.namespace }}/{{ $labels.name }} will expire in less then 29 days',
+              summary: 'Certificate managed by Cert-Manager will expire soon in less then 29 days',
+              runbook_url: '%(runBookBaseURL)s/core/CertManager.md#CertManagerCertificateExpireSoon' % $._config,
+            },
+            expr: 'certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 2506000',
+            'for': '60m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            alert: 'CertManagerCertificateExpireSoon',
+            annotations: {
+              description: 'Cert Manager managed certificate for {{ $labels.namespace }}/{{ $labels.name }} will expire in less then 14 days',
+              summary: 'Certificate managed by Cert-Manager will expire soon in less then 14 days',
+              runbook_url: '%(runBookBaseURL)s/core/CertManager.md#CertManagerCertificateExpireSoon' % $._config,
+            },
+            expr: 'certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 1210000',
+            'for': '60m',
+            labels: {
+              page: 'false',
+              severity: 'critical',
+            },
+          },
+          {
+            alert: 'CertManagerCertificateNotReady',
+            annotations: {
+              description: 'Cert Manager certificate for {{ $labels.namespace }}/{{ $labels.name }} has not reached Ready status in 60 minutes',
+              summary: 'Certificate managed by Cert-Manager has not reached Ready Status in 60 minutes',
+              runbook_url: '%(runBookBaseURL)s/core/CertManager.md#CertManagerCertificateNotReady' % $._config,
+            },
+            expr: 'certmanager_certificate_ready_status{job="cert-manager",condition="True"} == 0',
+            'for': '60m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/lib/mintel/alerts/external-dns.libsonnet
+++ b/lib/mintel/alerts/external-dns.libsonnet
@@ -11,8 +11,21 @@
               summary: 'External DNS Last Sync is very Old',
               runbook_url: '%(runBookBaseURL)s/core/ExternalDNS.md#ExternalDnsLastSyncOld' % $._config,
             },
-            expr: 'time() - external_dns_controller_last_sync_timestamp_seconds{job="external-dns"} > 90',
+            expr: '(time() - external_dns_controller_last_sync_timestamp_seconds{job="external-dns"} > 90) or external_dns_controller_last_sync_timestamp_seconds{job="external-dns"} == 0',
             'for': '10m',
+            labels: {
+              severity: 'warning',
+            },
+          },
+          {
+            alert: 'ExternalDnsRegistryErrorsIncrease',
+            annotations: {
+              description: 'External DNS registry Errors increasing constantly',
+              summary: 'External DNS registry Errors increasing constantly',
+              runbook_url: '%(runBookBaseURL)s/core/ExternalDNS.md#ExternalDnsRegistryErrorsIncrease' % $._config,
+            },
+            expr: 'increase(external_dns_registry_errors_total{job="external-dns"}[5m]) > 0',
+            'for': '30m',
             labels: {
               severity: 'warning',
             },

--- a/lib/mintel/alerts/flux.libsonnet
+++ b/lib/mintel/alerts/flux.libsonnet
@@ -11,7 +11,7 @@
               summary: 'General Flux Daemon sync error',
               runbook_url: '%(runBookBaseURL)s/core/flux.md#fluxdaemongeneralsyncerror' % $._config,
             },
-            expr: 'delta(flux_daemon_sync_duration_seconds_count{%(fluxJobSelector)s,success="true"}[%(fluxDeltaIntervalMinutes)sm]) < 1' % $._config,
+            expr: 'delta(flux_daemon_sync_duration_seconds_count{%(fluxJobSelector)s,success="true"}[%(fluxDeltaIntervalMinutes)sm]) < 1 or absent(flux_daemon_sync_duration_seconds_count{%(fluxJobSelector)s,success="true"})' % $._config,
             'for': '120m',
             labels: {
               severity: 'warning',

--- a/lib/mintel/dashboards/components/panels/backend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/backend-service.libsonnet
@@ -1,5 +1,6 @@
 local layout = import 'components/layout.libsonnet';
 local commonPanels = import 'components/panels/common.libsonnet';
+local workloadPanels = import 'components/panels/workloads.libsonnet';
 {
 
   overview(serviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
@@ -9,31 +10,7 @@ local commonPanels = import 'components/panels/common.libsonnet';
     };
     layout.grid([
 
-      commonPanels.timeseries(
-        title='Workloads Status',
-        description='Percentage of instances up (by workload)',
-        span=4,
-        max=100,
-        format='percent',
-        legend_show=false,
-        // Fix legendFormat to display deployment/statefulset (needs relabel)
-        thresholds=[
-          {'value': 50,
-          'colorMode': 'critical',
-          'op': 'lt',
-          'fill': true,
-          'line': true
-        }],
-        query=|||
-          sum by (deployment, statefulset)
-            (
-              100 * (kube_deployment_status_replicas_available{namespace=~"$namespace"}) /(kube_deployment_spec_replicas{namespace=~"$namespace"})
-              or
-              100 * (kube_statefulset_status_replicas_ready{namespace=~"$namespace"}) /(kube_statefulset_status_replicas{namespace=~"$namespace"})
-            )
-        ||| % config,
-      ),
-
+      workloadPanels.workloadStatus(),
       commonPanels.singlestat(
         title='Incoming Request Volume',
         description='Requests per second (all http-status)',

--- a/lib/mintel/dashboards/components/panels/backend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/backend-service.libsonnet
@@ -4,7 +4,7 @@ local httpPanels = import 'components/panels/http.libsonnet';
 
 {
 
-  overview(segitrviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
+  overview(serviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
     local config = {
       serviceSelectorKey: serviceSelectorKey,
       serviceSelectorValue: serviceSelectorValue,

--- a/lib/mintel/dashboards/components/panels/backend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/backend-service.libsonnet
@@ -1,59 +1,18 @@
 local layout = import 'components/layout.libsonnet';
-local commonPanels = import 'components/panels/common.libsonnet';
 local workloadPanels = import 'components/panels/workloads.libsonnet';
+local httpPanels = import 'components/panels/http.libsonnet';
+
 {
 
-  overview(serviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
+  overview(segitrviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
     local config = {
       serviceSelectorKey: serviceSelectorKey,
       serviceSelectorValue: serviceSelectorValue,
     };
     layout.grid([
-
       workloadPanels.workloadStatus(),
-      commonPanels.singlestat(
-        title='Incoming Request Volume',
-        description='Requests per second (all http-status)',
-        colorBackground=true,
-        format='rps',
-        sparklineShow=true,
-        span=4,
-        query=|||
-          sum(
-            rate(
-              http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
-        ||| % config,
-      ),
-      commonPanels.singlestat(
-        title='Incoming Success Rate',
-        description='Percentage of successful (non http-5xx) requests',
-        colorBackground=true,
-        format='percent',
-        sparklineShow=true,
-        thresholds="99,95",
-        colors=[
-          '#d44a3a',
-          'rgba(237, 129, 40, 0.89)',
-          '#299c46',
-        ],
-        span=4,
-        query=|||
-          100 - (
-            sum by (service, app_mintel_com_owner)
-              (
-                rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s", status_code=~"5.."}[$__interval])
-                    or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
-              )
-
-            /
-            sum by (service, app_mintel_com_owner)
-              (
-                rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval])
-                  or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
-              )
-          ) * 100
-        ||| % config,
-      ),
+      httpPanels.httpBackendRequestsPerSecond(config.serviceSelectorKey, config.serviceSelectorValue),
+      httpPanels.httpBackendSuccessRatioPercentage(config.serviceSelectorKey, config.serviceSelectorValue),
 
     ], cols=12, rowHeight=10, startRow=startRow),
 }

--- a/lib/mintel/dashboards/components/panels/backend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/backend-service.libsonnet
@@ -1,0 +1,82 @@
+local layout = import 'components/layout.libsonnet';
+local commonPanels = import 'components/panels/common.libsonnet';
+{
+
+  overview(serviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+    layout.grid([
+
+      commonPanels.timeseries(
+        title='Workloads Status',
+        description='Percentage of instances up (by workload)',
+        span=4,
+        max=100,
+        format='percent',
+        legend_show=false,
+        // Fix legendFormat to display deployment/statefulset (needs relabel)
+        thresholds=[
+          {'value': 50,
+          'colorMode': 'critical',
+          'op': 'lt',
+          'fill': true,
+          'line': true
+        }],
+        query=|||
+          sum by (deployment, statefulset)
+            (
+              100 * (kube_deployment_status_replicas_available{namespace=~"$namespace"}) /(kube_deployment_spec_replicas{namespace=~"$namespace"})
+              or
+              100 * (kube_statefulset_status_replicas_ready{namespace=~"$namespace"}) /(kube_statefulset_status_replicas{namespace=~"$namespace"})
+            )
+        ||| % config,
+      ),
+
+      commonPanels.singlestat(
+        title='Incoming Request Volume',
+        description='Requests per second (all http-status)',
+        colorBackground=true,
+        format='rps',
+        sparklineShow=true,
+        span=4,
+        query=|||
+          sum(
+            rate(
+              http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+        ||| % config,
+      ),
+      commonPanels.singlestat(
+        title='Incoming Success Rate',
+        description='Percentage of successful (non http-5xx) requests',
+        colorBackground=true,
+        format='percent',
+        sparklineShow=true,
+        thresholds="99,95",
+        colors=[
+          '#d44a3a',
+          'rgba(237, 129, 40, 0.89)',
+          '#299c46',
+        ],
+        span=4,
+        query=|||
+          100 - (
+            sum by (service, app_mintel_com_owner)
+              (
+                rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s", status_code=~"5.."}[$__interval])
+                    or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
+              )
+
+            /
+            sum by (service, app_mintel_com_owner)
+              (
+                rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval])
+                  or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
+              )
+          ) * 100
+        ||| % config,
+      ),
+
+    ], cols=12, rowHeight=10, startRow=startRow),
+}

--- a/lib/mintel/dashboards/components/panels/container_resources.libsonnet
+++ b/lib/mintel/dashboards/components/panels/container_resources.libsonnet
@@ -1,0 +1,38 @@
+local layout = import 'components/layout.libsonnet';
+local commonPanels = import 'components/panels/common.libsonnet';
+local promQuery = import 'components/prom_query.libsonnet';
+{
+ 
+  containerResourcesPanel(podSelectorValue, containerName='main', startRow=1000)::
+    local config = {
+      podSelectorValue: podSelectorValue,
+      containerName: containerName,
+    };
+    layout.grid([
+      commonPanels.timeseries(
+        title='Per Instance CPU',
+        yAxisLabel='CPU Usage',
+        span=6,
+        legend_show=false,
+        query=|||
+          sum(
+            rate(
+              container_cpu_usage_seconds_total{namespace="$namespace", pod=~"%(podSelectorValue)s.*", container="%(containerName)s"}[5m])) by (pod)
+        ||| % config,
+        legendFormat='{{ pod }}',
+        intervalFactor=2,
+      ),
+
+      commonPanels.timeseries(
+        title='Per Instance Memory',
+        yAxisLabel='Memory Usage',
+        span=6,
+        legend_show=false,
+        query=|||
+          container_memory_usage_bytes{namespace="$namespace", pod=~"%(podSelectorValue)s.*", container="%(containerName)s"}
+        ||| % config,
+        legendFormat='{{ pod }}',
+        intervalFactor=2,
+      ),
+    ], cols=2, rowHeight=10, startRow=startRow),
+}

--- a/lib/mintel/dashboards/components/panels/django.libsonnet
+++ b/lib/mintel/dashboards/components/panels/django.libsonnet
@@ -30,39 +30,6 @@ local promQuery = import 'components/prom_query.libsonnet';
       ),
     ], cols=12, rowHeight=10, startRow=startRow),
 
-  resourcePanels(serviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
-    local config = {
-      serviceSelectorKey: serviceSelectorKey,
-      serviceSelectorValue: serviceSelectorValue,
-    };
-    layout.grid([
-      commonPanels.timeseries(
-        title='Per Instance CPU',
-        yAxisLabel='CPU Usage',
-        span=6,
-        legend_show=false,
-        query=|||
-          sum(
-            rate(
-              container_cpu_usage_seconds_total{namespace="$namespace", pod=~"$service.*", container="main"}[5m])) by (pod)
-        ||| % config,
-        legendFormat='{{ pod }}',
-        intervalFactor=2,
-      ),
-
-      commonPanels.timeseries(
-        title='Per Instance Memory',
-        yAxisLabel='Memory Usage',
-        span=6,
-        legend_show=false,
-        query=|||
-          container_memory_usage_bytes{namespace="$namespace", pod=~"$service-.*", container="main"}
-        ||| % config,
-        legendFormat='{{ pod }}',
-        intervalFactor=2,
-      ),
-    ], cols=2, rowHeight=10, startRow=startRow),
-
   databaseOps(serviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
     local config = {
       serviceSelectorKey: serviceSelectorKey,

--- a/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
@@ -1,5 +1,4 @@
 local layout = import 'components/layout.libsonnet';
-local commonPanels = import 'components/panels/common.libsonnet';
 local haproxyPanels = import 'components/panels/haproxy.libsonnet';
 local workloadPanels = import 'components/panels/workloads.libsonnet';
 

--- a/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
@@ -35,36 +35,7 @@ local haproxyPanels = import 'components/panels/haproxy.libsonnet';
         ||| % config,
       ),
 
-      commonPanels.singlestat(
-        title='Incoming Request Volume',
-        description='Requests per second (all http-status)',
-        colorBackground=true,
-        format='rps',
-        sparklineShow=true,
-        span=4,
-        query=|||
-          sum(
-            rate(
-              haproxy:haproxy_backend_http_responses_total:counter{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[$__interval]))
-        ||| % config,
-      ),
-      commonPanels.singlestat(
-        title='Incoming Success Rate',
-        description='Percentage of successful (non http-5xx) requests',
-        colorBackground=true,
-        format='percent',
-        sparklineShow=true,
-        thresholds="99,95",
-        colors=[
-          '#d44a3a',
-          'rgba(237, 129, 40, 0.89)',
-          '#299c46',
-        ],
-        span=4,
-        query=|||
-          100 - haproxy:haproxy_backend_http_error_rate:percentage:1m{mintel_com_service="$namespace-%(serviceSelectorValue)s"}
-        ||| % config,
-      ),
-
+      haproxyPanels.httpBackendRequestsPerSecond(config.serviceSelectorKey, config.serviceSelectorValue),
+      haproxyPanels.httpBackendSuccessRatioPercentage(config.serviceSelectorKey, config.serviceSelectorValue),
     ], cols=12, rowHeight=10, startRow=startRow),
 }

--- a/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
@@ -1,6 +1,8 @@
 local layout = import 'components/layout.libsonnet';
 local commonPanels = import 'components/panels/common.libsonnet';
 local haproxyPanels = import 'components/panels/haproxy.libsonnet';
+local workloadPanels = import 'components/panels/workloads.libsonnet';
+
 {
 
   overview(serviceSelectorKey='service', serviceSelectorValue='$service', startRow=1000)::
@@ -9,32 +11,7 @@ local haproxyPanels = import 'components/panels/haproxy.libsonnet';
       serviceSelectorValue: serviceSelectorValue,
     };
     layout.grid([
-
-      commonPanels.timeseries(
-        title='Workloads Status',
-        description='Percentage of instances up (by workload)',
-        span=4,
-        max=100,
-        format='percent',
-        legend_show=false,
-        // Fix legendFormat to display deployment/statefulset (needs relabel)
-        thresholds=[
-          {'value': 50,
-          'colorMode': 'critical',
-          'op': 'lt',
-          'fill': true,
-          'line': true
-        }],
-        query=|||
-          sum by (deployment, statefulset)
-            (
-              100 * (kube_deployment_status_replicas_available{namespace=~"$namespace"}) / (kube_deployment_spec_replicas{namespace=~"$namespace"})
-              or
-              100 * (kube_statefulset_status_replicas_ready{namespace=~"$namespace"}) / (kube_statefulset_status_replicas{namespace=~"$namespace"})
-            )
-        ||| % config,
-      ),
-
+      workloadPanels.workloadStatus(),
       haproxyPanels.httpBackendRequestsPerSecond(config.serviceSelectorKey, config.serviceSelectorValue),
       haproxyPanels.httpBackendSuccessRatioPercentage(config.serviceSelectorKey, config.serviceSelectorValue),
     ], cols=12, rowHeight=10, startRow=startRow),

--- a/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
+++ b/lib/mintel/dashboards/components/panels/frontend-service.libsonnet
@@ -28,9 +28,9 @@ local haproxyPanels = import 'components/panels/haproxy.libsonnet';
         query=|||
           sum by (deployment, statefulset)
             (
-              100 * (kube_deployment_status_replicas_available{namespace=~"$namespace"}) /(kube_deployment_spec_replicas{namespace=~"$namespace"})
+              100 * (kube_deployment_status_replicas_available{namespace=~"$namespace"}) / (kube_deployment_spec_replicas{namespace=~"$namespace"})
               or
-              100 * (kube_statefulset_status_replicas_ready{namespace=~"$namespace"}) /(kube_statefulset_status_replicas{namespace=~"$namespace"})
+              100 * (kube_statefulset_status_replicas_ready{namespace=~"$namespace"}) / (kube_statefulset_status_replicas{namespace=~"$namespace"})
             )
         ||| % config,
       ),

--- a/lib/mintel/dashboards/components/panels/haproxy.libsonnet
+++ b/lib/mintel/dashboards/components/panels/haproxy.libsonnet
@@ -161,8 +161,4 @@ local promQuery = import 'components/prom_query.libsonnet';
         100 - haproxy:haproxy_backend_http_error_rate:percentage:1m{mintel_com_service="$namespace-%(serviceSelectorValue)s"}
       ||| % config,
     ),
-
-
-
-
 }

--- a/lib/mintel/dashboards/components/panels/haproxy.libsonnet
+++ b/lib/mintel/dashboards/components/panels/haproxy.libsonnet
@@ -117,4 +117,52 @@ local promQuery = import 'components/prom_query.libsonnet';
       legendFormat='{{ code }}',
       intervalFactor=2,
     ),
+
+
+  httpBackendRequestsPerSecond(serviceSelectorKey='service', serviceSelectorValue='$service', span=4)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+    commonPanels.singlestat(
+      title='Incoming Request Volume',
+      description='Requests per second (all http-status)',
+      colorBackground=true,
+      format='rps',
+      sparklineShow=true,
+      span=span,
+      query=|||
+        sum(
+          rate(
+            haproxy:haproxy_backend_http_responses_total:counter{backend=~"$namespace-.*%(serviceSelectorValue)s-[0-9].*"}[$__interval]))
+      ||| % config,
+    ),
+
+  httpBackendSuccessRatioPercentage(serviceSelectorKey='service', serviceSelectorValue='$service', span=4)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+
+    commonPanels.singlestat(
+      title='Incoming Success Rate',
+      description='Percentage of successful (non http-5xx) requests',
+      colorBackground=true,
+      format='percent',
+      sparklineShow=true,
+      thresholds="99,95",
+      colors=[
+        '#d44a3a',
+        'rgba(237, 129, 40, 0.89)',
+        '#299c46',
+      ],
+      span=span,
+      query=|||
+        100 - haproxy:haproxy_backend_http_error_rate:percentage:1m{mintel_com_service="$namespace-%(serviceSelectorValue)s"}
+      ||| % config,
+    ),
+
+
+
+
 }

--- a/lib/mintel/dashboards/components/panels/http.libsonnet
+++ b/lib/mintel/dashboards/components/panels/http.libsonnet
@@ -15,7 +15,7 @@ local commonPanels = import 'components/panels/common.libsonnet';
       query=|||
         sum(
           rate(
-            http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+            http_requests_total{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
       ||| % config,
     ),
 
@@ -39,20 +39,7 @@ local commonPanels = import 'components/panels/common.libsonnet';
       ],
       span=4,
       query=|||
-        100 - (
-          sum by (service, app_mintel_com_owner)
-            (
-              rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s", status_code=~"5.."}[$__interval])
-                  or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
-            )
-
-          /
-          sum by (service, app_mintel_com_owner)
-            (
-              rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval])
-                or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
-            )
-        ) * 100
+        100 - mintel:http_error_rate:percentage:1m{%(serviceSelectorKey)s="%(serviceSelectorValue)s"}
       ||| % config,
     ),
 }

--- a/lib/mintel/dashboards/components/panels/http.libsonnet
+++ b/lib/mintel/dashboards/components/panels/http.libsonnet
@@ -1,0 +1,58 @@
+local commonPanels = import 'components/panels/common.libsonnet';
+{
+  httpBackendRequestsPerSecond(serviceSelectorKey='service', serviceSelectorValue='$service', span=4)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+    commonPanels.singlestat(
+      title='Incoming Request Volume',
+      description='Requests per second (all http-status)',
+      colorBackground=true,
+      format='rps',
+      sparklineShow=true,
+      span=4,
+      query=|||
+        sum(
+          rate(
+            http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+      ||| % config,
+    ),
+
+  httpBackendSuccessRatioPercentage(serviceSelectorKey='service', serviceSelectorValue='$service', span=4)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+
+    commonPanels.singlestat(
+      title='Incoming Success Rate',
+      description='Percentage of successful (non http-5xx) requests',
+      colorBackground=true,
+      format='percent',
+      sparklineShow=true,
+      thresholds="99,95",
+      colors=[
+        '#d44a3a',
+        'rgba(237, 129, 40, 0.89)',
+        '#299c46',
+      ],
+      span=4,
+      query=|||
+        100 - (
+          sum by (service, app_mintel_com_owner)
+            (
+              rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s", status_code=~"5.."}[$__interval])
+                  or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
+            )
+
+          /
+          sum by (service, app_mintel_com_owner)
+            (
+              rate(http_request_duration_seconds_count{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval])
+                or 0 * up{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}
+            )
+        ) * 100
+      ||| % config,
+    ),
+}

--- a/lib/mintel/dashboards/components/panels/thumbor.libsonnet
+++ b/lib/mintel/dashboards/components/panels/thumbor.libsonnet
@@ -16,40 +16,6 @@ local promQuery = import 'components/prom_query.libsonnet';
 
     ], cols=12, rowHeight=10, startRow=startRow),
 
-  resourcePanels(serviceSelectorKey='job', serviceSelectorValue='$deployment', startRow=1000)::
-    local config = {
-      serviceSelectorKey: serviceSelectorKey,
-      serviceSelectorValue: serviceSelectorValue,
-    };
-    layout.grid([
-
-      commonPanels.timeseries(
-        title='Per Instance CPU',
-        yAxisLabel='CPU Usage',
-        span=6,
-        legend_show=false,
-        query=|||
-          sum(
-            rate(
-              container_cpu_usage_seconds_total{namespace="$namespace", pod=~"$deployment.*", container="main"}[5m])) by (pod)
-        ||| % config,
-        legendFormat='{{ pod }}',
-        intervalFactor=2,
-      ),
-
-      commonPanels.timeseries(
-        title='Per Instance Memory',
-        yAxisLabel='Memory Usage',
-        span=6,
-        legend_show=false,
-        query=|||
-          sum(container_memory_usage_bytes{namespace="$namespace", pod=~"$deployment-.*", container="main"}) by (pod)
-        ||| % config,
-        legendFormat='{{ pod }}',
-        intervalFactor=2,
-      ),
-    ], cols=2, rowHeight=200, startRow=startRow),
-
   storagePanels(serviceSelectorKey='job', serviceSelectorValue='$deployment', startRow=1000)::
     local config = {
       serviceSelectorKey: serviceSelectorKey,

--- a/lib/mintel/dashboards/components/panels/workloads.libsonnet
+++ b/lib/mintel/dashboards/components/panels/workloads.libsonnet
@@ -1,0 +1,28 @@
+local commonPanels = import 'components/panels/common.libsonnet';
+{
+  workloadStatus(thresholdPercent=50, max=100, span=4)::
+    commonPanels.timeseries(
+      title='Workloads Status',
+      description='Percentage of instances up (by workload)',
+      span=span,
+      max=max,
+      format='percent',
+      legend_show=false,
+      // Fix legendFormat to display deployment/statefulset (needs relabel)
+      thresholds=[
+        {'value': thresholdPercent,
+        'colorMode': 'critical',
+        'op': 'lt',
+        'fill': true,
+        'line': true
+      }],
+      query=|||
+        sum by (deployment, statefulset)
+          (
+            100 * (kube_deployment_status_replicas_available{namespace=~"$namespace"}) / (kube_deployment_spec_replicas{namespace=~"$namespace"})
+            or
+            100 * (kube_statefulset_status_replicas_ready{namespace=~"$namespace"}) / (kube_statefulset_status_replicas{namespace=~"$namespace"})
+          )
+      |||
+    ),
+}

--- a/lib/mintel/dashboards/components/templates.libsonnet
+++ b/lib/mintel/dashboards/components/templates.libsonnet
@@ -42,6 +42,7 @@ local template = grafana.template;
     current=current,
     hide=hide,
   ),
+
   app_service:: template.new(
     'service',
     'Prometheus',

--- a/lib/mintel/dashboards/dashboards.libsonnet
+++ b/lib/mintel/dashboards/dashboards.libsonnet
@@ -1,6 +1,8 @@
 (import './core-cluster/capacity.libsonnet') +
 (import './services/portal/overview.libsonnet') +
 (import './services/image-service/overview.libsonnet') +
+(import './services/omni/omni-web-overview.libsonnet') +
+(import './services/omni/omni-analytics-overview.libsonnet') +
 (import './cost-analysis/cost-analysis-by-cluster.libsonnet') +
 (import './cost-analysis/cost-analysis-by-namespace.libsonnet') +
 (import './cost-analysis/cost-analysis-by-pod.libsonnet') +

--- a/lib/mintel/dashboards/services/image-service/overview.libsonnet
+++ b/lib/mintel/dashboards/services/image-service/overview.libsonnet
@@ -7,7 +7,7 @@ local annotations = import 'components/annotations.libsonnet';
 
 local templates = import 'components/templates.libsonnet';
 local thumbor = import 'components/panels/thumbor.libsonnet';
-local webService = import 'components/panels/web-service.libsonnet';
+local webService = import 'components/panels/frontend-service.libsonnet';
 local containerResources = import 'components/panels/container_resources.libsonnet';
 
 // Dashboard settings

--- a/lib/mintel/dashboards/services/image-service/overview.libsonnet
+++ b/lib/mintel/dashboards/services/image-service/overview.libsonnet
@@ -8,6 +8,7 @@ local annotations = import 'components/annotations.libsonnet';
 local templates = import 'components/templates.libsonnet';
 local thumbor = import 'components/panels/thumbor.libsonnet';
 local webService = import 'components/panels/web-service.libsonnet';
+local containerResources = import 'components/panels/container_resources.libsonnet';
 
 // Dashboard settings
 local dashboardTitle = 'Image Service';
@@ -59,7 +60,7 @@ local dashboardTags = ['image-service'];
       )
       .addRow(
         row.new('Resources')
-        .addPanels(thumbor.resourcePanels())
+        .addPanels(containerResources.containerResourcesPanel("$deployment"))
       )
       .addRow(
         row.new('Storage')

--- a/lib/mintel/dashboards/services/omni/analytics.libsonnet
+++ b/lib/mintel/dashboards/services/omni/analytics.libsonnet
@@ -12,8 +12,8 @@ local promQuery = import 'components/prom_query.libsonnet';
     layout.grid([
 
     commonPanels.latencyTimeseries(
-      title='API Server Latency',
-      description='Percentile Latency For Analytics API Server',
+      title='API Service Latency',
+      description='Percentile Latency For Analytics API Service',
       yAxisLabel='Time',
       format='s',
       legend_show=true,

--- a/lib/mintel/dashboards/services/omni/analytics.libsonnet
+++ b/lib/mintel/dashboards/services/omni/analytics.libsonnet
@@ -23,7 +23,7 @@ local promQuery = import 'components/prom_query.libsonnet';
         histogram_quantile(0.95,
           sum(
             rate(
-              http_request_duration_seconds_bucket{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+              http_request_duration_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
         by (service, analytics_type, le))
       ||| % config,
       legendFormat='p95 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
@@ -35,7 +35,7 @@ local promQuery = import 'components/prom_query.libsonnet';
           histogram_quantile(0.75,
           sum(
             rate(
-              http_request_duration_seconds_bucket{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+              http_request_duration_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
           by (service, analytics_type, le))
         ||| % config,
         legendFormat='p75 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
@@ -48,7 +48,7 @@ local promQuery = import 'components/prom_query.libsonnet';
           histogram_quantile(0.50,
           sum(
             rate(
-              http_request_duration_seconds_bucket{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+              http_request_duration_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
           by (service, analytics_type, le))
         ||| % config,
         legendFormat='p50 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),

--- a/lib/mintel/dashboards/services/omni/analytics.libsonnet
+++ b/lib/mintel/dashboards/services/omni/analytics.libsonnet
@@ -1,0 +1,59 @@
+local layout = import 'components/layout.libsonnet';
+local commonPanels = import 'components/panels/common.libsonnet';
+local promQuery = import 'components/prom_query.libsonnet';
+{
+
+  latencyTimeseries(serviceSelectorKey='service', serviceSelectorValue='$service', span=12)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+
+    layout.grid([
+
+    commonPanels.latencyTimeseries(
+      title='API Server Latency',
+      description='Percentile Latency For Analytics API Server',
+      yAxisLabel='Time',
+      format='s',
+      legend_show=true,
+      span=span,
+      height=300,
+      query=|||
+        histogram_quantile(0.95,
+          sum(
+            rate(
+              http_request_duration_seconds_bucket{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+        by (service, analytics_type, le))
+      ||| % config,
+      legendFormat='p95 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+      intervalFactor=2,
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.75,
+          sum(
+            rate(
+              http_request_duration_seconds_bucket{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+          by (service, analytics_type, le))
+        ||| % config,
+        legendFormat='p75 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+        intervalFactor=2,
+      )
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.50,
+          sum(
+            rate(
+              http_request_duration_seconds_bucket{namespace="$namespace", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+          by (service, analytics_type, le))
+        ||| % config,
+        legendFormat='p50 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+        intervalFactor=2,
+      )
+    ),
+  ]),
+}

--- a/lib/mintel/dashboards/services/omni/analytics.libsonnet
+++ b/lib/mintel/dashboards/services/omni/analytics.libsonnet
@@ -3,7 +3,7 @@ local commonPanels = import 'components/panels/common.libsonnet';
 local promQuery = import 'components/prom_query.libsonnet';
 {
 
-  latencyTimeseries(serviceSelectorKey='service', serviceSelectorValue='$service', span=12)::
+  apiServiceLatency(serviceSelectorKey='service', serviceSelectorValue='$service', span=12)::
     local config = {
       serviceSelectorKey: serviceSelectorKey,
       serviceSelectorValue: serviceSelectorValue,
@@ -56,4 +56,107 @@ local promQuery = import 'components/prom_query.libsonnet';
       )
     ),
   ]),
+
+  elasticSearchResponses(serviceSelectorKey='service', serviceSelectorValue='$service', span=12)::
+    local config = {
+      serviceSelectorKey: serviceSelectorKey,
+      serviceSelectorValue: serviceSelectorValue,
+    };
+
+    layout.grid([
+
+    commonPanels.latencyTimeseries(
+      title='ElasticSearch Response Latency',
+      description='Percentile Latency For Analytics ElasticSearch Responses',
+      yAxisLabel='Time',
+      format='s',
+      legend_show=true,
+      span=span,
+      height=300,
+      query=|||
+        histogram_quantile(0.95,
+          sum(
+            rate(
+              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+        by (service, analytics_type, le))
+      ||| % config,
+      legendFormat='p95 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+      intervalFactor=2,
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.75,
+          sum(
+            rate(
+              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+          by (service, analytics_type, le))
+        ||| % config,
+        legendFormat='p75 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+        intervalFactor=2,
+      )
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.50,
+          sum(
+            rate(
+              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+          by (service, analytics_type, le))
+        ||| % config,
+        legendFormat='p50 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+        intervalFactor=2,
+      )
+    ),
+
+   commonPanels.latencyTimeseries(
+      title='ElasticSearch Response Latency',
+      description='Percentile Latency For Analytics ElasticSearch Responses',
+      yAxisLabel='Time',
+      format='s',
+      legend_show=true,
+      span=span,
+      height=300,
+      query=|||
+        histogram_quantile(0.95,
+          sum(
+            rate(
+              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+        by (service, analytics_type, le))
+      ||| % config,
+      legendFormat='p95 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+      intervalFactor=2,
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.75,
+          sum(
+            rate(
+              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+          by (service, analytics_type, le))
+        ||| % config,
+        legendFormat='p75 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+        intervalFactor=2,
+      )
+    )
+    .addTarget(
+      promQuery.target(
+        |||
+          histogram_quantile(0.50,
+          sum(
+            rate(
+              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
+          by (service, analytics_type, le))
+        ||| % config,
+        legendFormat='p50 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
+        intervalFactor=2,
+      )
+    ),
+
+
+
+  ]),
+
 }

--- a/lib/mintel/dashboards/services/omni/analytics.libsonnet
+++ b/lib/mintel/dashboards/services/omni/analytics.libsonnet
@@ -109,54 +109,5 @@ local promQuery = import 'components/prom_query.libsonnet';
         intervalFactor=2,
       )
     ),
-
-   commonPanels.latencyTimeseries(
-      title='ElasticSearch Response Latency',
-      description='Percentile Latency For Analytics ElasticSearch Responses',
-      yAxisLabel='Time',
-      format='s',
-      legend_show=true,
-      span=span,
-      height=300,
-      query=|||
-        histogram_quantile(0.95,
-          sum(
-            rate(
-              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
-        by (service, analytics_type, le))
-      ||| % config,
-      legendFormat='p95 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
-      intervalFactor=2,
-    )
-    .addTarget(
-      promQuery.target(
-        |||
-          histogram_quantile(0.75,
-          sum(
-            rate(
-              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
-          by (service, analytics_type, le))
-        ||| % config,
-        legendFormat='p75 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
-        intervalFactor=2,
-      )
-    )
-    .addTarget(
-      promQuery.target(
-        |||
-          histogram_quantile(0.50,
-          sum(
-            rate(
-              omni_analytics_es_request_processing_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
-          by (service, analytics_type, le))
-        ||| % config,
-        legendFormat='p50 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
-        intervalFactor=2,
-      )
-    ),
-
-
-
-  ]),
-
+ ]),
 }

--- a/lib/mintel/dashboards/services/omni/analytics.libsonnet
+++ b/lib/mintel/dashboards/services/omni/analytics.libsonnet
@@ -20,11 +20,7 @@ local promQuery = import 'components/prom_query.libsonnet';
       span=span,
       height=300,
       query=|||
-        histogram_quantile(0.95,
-          sum(
-            rate(
-              http_request_duration_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
-        by (service, analytics_type, le))
+        mintel:http_request_duration_seconds_quantile:95{%(serviceSelectorKey)s="%(serviceSelectorValue)s", analytics_type=~"$analytics_type"}
       ||| % config,
       legendFormat='p95 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
       intervalFactor=2,
@@ -32,11 +28,7 @@ local promQuery = import 'components/prom_query.libsonnet';
     .addTarget(
       promQuery.target(
         |||
-          histogram_quantile(0.75,
-          sum(
-            rate(
-              http_request_duration_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
-          by (service, analytics_type, le))
+          mintel:http_request_duration_seconds_quantile:75{%(serviceSelectorKey)s="%(serviceSelectorValue)s", analytics_type=~"$analytics_type"}
         ||| % config,
         legendFormat='p75 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
         intervalFactor=2,
@@ -45,11 +37,7 @@ local promQuery = import 'components/prom_query.libsonnet';
     .addTarget(
       promQuery.target(
         |||
-          histogram_quantile(0.50,
-          sum(
-            rate(
-              http_request_duration_seconds_bucket{namespace="$namespace", analytics_type=~"$analytics_type", %(serviceSelectorKey)s="%(serviceSelectorValue)s"}[$__interval]))
-          by (service, analytics_type, le))
+          mintel:http_request_duration_seconds_quantile:50{%(serviceSelectorKey)s="%(serviceSelectorValue)s", analytics_type=~"$analytics_type"}
         ||| % config,
         legendFormat='p50 {{ %(serviceSelectorKey)s }}/{{ analytics_type }}' % (config),
         intervalFactor=2,

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -6,6 +6,8 @@ local link = grafana.link;
 local annotations = import 'components/annotations.libsonnet';
 local templates = import 'components/templates.libsonnet';
 local backendService = import 'components/panels/backend-service.libsonnet';
+//local omniAnalytics = import 'analytics.libsonnet';
+local containerResources = import 'components/panels/container_resources.libsonnet';
 
 // Dashboard settings
 local dashboardTitle = 'Omni Analytics';
@@ -52,5 +54,14 @@ local dashboardTags = ['omni'];
         row.new('Overview', height=5)
         .addPanels(backendService.overview())
       )
+      //.addRow(
+      //  row.new('Analytics', height=5)
+      //  .addPanels(omniAnalytics.overview())
+     // )
+      .addRow(
+        row.new('Resources')
+        .addPanels(containerResources.containerResourcesPanel("$service"))
+      )
+
   },
 }

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -5,7 +5,7 @@ local link = grafana.link;
 
 local annotations = import 'components/annotations.libsonnet';
 local templates = import 'components/templates.libsonnet';
-local webService = import 'components/panels/web-service.libsonnet';
+local backendService = import 'components/panels/backend-service.libsonnet';
 
 // Dashboard settings
 local dashboardTitle = 'Omni Analytics';
@@ -50,7 +50,7 @@ local dashboardTags = ['omni'];
 
       .addRow(
         row.new('Overview', height=5)
-        .addPanels(webService.overview())
+        .addPanels(backendService.overview())
       )
   },
 }

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -5,9 +5,10 @@ local link = grafana.link;
 
 local annotations = import 'components/annotations.libsonnet';
 local templates = import 'components/templates.libsonnet';
+local containerResources = import 'components/panels/container_resources.libsonnet';
 local backendService = import 'components/panels/backend-service.libsonnet';
 local omniAnalytics = import 'analytics.libsonnet';
-local containerResources = import 'components/panels/container_resources.libsonnet';
+
 
 // Dashboard settings
 local dashboardTitle = 'Omni Analytics';

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -49,7 +49,17 @@ local dashboardTags = ['omni'];
       .addTemplate(templates.ds)
       .addTemplate(templates.namespace('omni', hide=true))
       .addTemplate(templates.app_service)
-
+      .addTemplate(grafana.template.new(
+        'analytics_type',
+        'Prometheus',
+        'label_values(http_request_duration_seconds_count{namespace="omni"}, analytics_type)',
+        label='Analytics Type',
+        refresh='time',
+        allValues='.*',
+        current='',
+        includeAll=true,
+        multi=true,
+      ))
       .addRow(
         row.new('Overview', height=5)
         .addPanels(backendService.overview())

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -1,0 +1,56 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local link = grafana.link;
+
+local annotations = import 'components/annotations.libsonnet';
+local templates = import 'components/templates.libsonnet';
+local webService = import 'components/panels/web-service.libsonnet';
+
+// Dashboard settings
+local dashboardTitle = 'Omni Analytics';
+local dashboardDescription = "Provides an overview of the Omni Analytics Stack";
+local dashboardFile = 'omni-analytics-overview.json';
+
+local dashboardUID = std.md5(dashboardFile);
+local dashboardLink = '/d/' + std.md5(dashboardFile);
+local dashboardWorkloadLink = '/d/fixme';
+
+local dashboardTags = ['omni'];
+// End dashboard settings
+
+{
+  grafanaDashboards+:: {
+    [std.format('%s', dashboardFile)]:
+      dashboard.new(
+        '%(dashboardNamePrefix)s %(dashboardTitle)s' %
+           ($._config.mintel + {'dashboardTitle': dashboardTitle }),
+        time_from='now-1h',
+        uid=dashboardUID,
+        tags=($._config.mintel.dashboardTags) + dashboardTags,
+        description=dashboardDescription,
+        graphTooltip='shared_crosshair',
+      )
+
+      .addLink(link.dashboards(tags="",
+        type="link",
+        title="Workload",
+        url=dashboardWorkloadLink,
+        includeVars=true,
+        keepTime=true,
+        asDropdown=false,
+        targetBlank=true))
+
+      .addAnnotation(annotations.fluxRelease)
+      .addAnnotation(annotations.fluxAutoRelease)
+
+      .addTemplate(templates.ds)
+      .addTemplate(templates.namespace('omni', hide=true))
+      .addTemplate(templates.app_service)
+
+      .addRow(
+        row.new('Overview', height=5)
+        .addPanels(webService.overview())
+      )
+  },
+}

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -16,7 +16,7 @@ local dashboardFile = 'omni-analytics-overview.json';
 
 local dashboardUID = std.md5(dashboardFile);
 local dashboardLink = '/d/' + std.md5(dashboardFile);
-local dashboardWorkloadLink = '/d/fixme';
+local dashboardWorkloadLink = '/d/a164a7f0339f99e89cea5cb47e9be617';
 
 local dashboardTags = ['omni'];
 // End dashboard settings

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -6,7 +6,7 @@ local link = grafana.link;
 local annotations = import 'components/annotations.libsonnet';
 local templates = import 'components/templates.libsonnet';
 local backendService = import 'components/panels/backend-service.libsonnet';
-//local omniAnalytics = import 'analytics.libsonnet';
+local omniAnalytics = import 'analytics.libsonnet';
 local containerResources = import 'components/panels/container_resources.libsonnet';
 
 // Dashboard settings
@@ -54,10 +54,10 @@ local dashboardTags = ['omni'];
         row.new('Overview', height=5)
         .addPanels(backendService.overview())
       )
-      //.addRow(
-      //  row.new('Analytics', height=5)
-      //  .addPanels(omniAnalytics.overview())
-     // )
+      .addRow(
+        row.new('Analytics', height=5)
+        .addPanels(omniAnalytics.latencyTimeseries())
+      )
       .addRow(
         row.new('Resources')
         .addPanels(containerResources.containerResourcesPanel("$service"))

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -65,8 +65,12 @@ local dashboardTags = ['omni'];
         .addPanels(backendService.overview())
       )
       .addRow(
-        row.new('Analytics', height=5)
-        .addPanels(omniAnalytics.latencyTimeseries())
+        row.new('API Service', height=5)
+        .addPanels(omniAnalytics.apiServiceLatency())
+      )
+      .addRow(
+        row.new('ES Responses', height=5)
+        .addPanels(omniAnalytics.elasticSearchResponses())
       )
       .addRow(
         row.new('Resources')

--- a/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
@@ -9,6 +9,8 @@ local redis = import 'components/panels/redis.libsonnet';
 local django = import 'components/panels/django.libsonnet';
 local celery = import 'components/panels/celery.libsonnet';
 local webService = import 'components/panels/web-service.libsonnet';
+local containerResources = import 'components/panels/container_resources.libsonnet';
+
 
 // Dashboard settings
 local dashboardTitle = 'Omni Web';
@@ -61,7 +63,7 @@ local dashboardTags = ['omni'];
       )
       .addRow(
         row.new('Resources')
-        .addPanels(django.resourcePanels())  
+        .addPanels(containerResources.containerResourcesPanel("$service"))
       )
       .addRow(
         row.new('Database', collapse=true)

--- a/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
@@ -1,0 +1,81 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local link = grafana.link;
+
+local annotations = import 'components/annotations.libsonnet';
+local templates = import 'components/templates.libsonnet';
+local redis = import 'components/panels/redis.libsonnet';
+local django = import 'components/panels/django.libsonnet';
+local celery = import 'components/panels/celery.libsonnet';
+local webService = import 'components/panels/web-service.libsonnet';
+
+// Dashboard settings
+local dashboardTitle = 'Omni Web';
+local dashboardDescription = "Provides an overview of the Omni Web Stack";
+local dashboardFile = 'omni-web-overview.json';
+
+local dashboardUID = std.md5(dashboardFile);
+local dashboardLink = '/d/' + std.md5(dashboardFile);
+local dashboardWorkloadLink = '/d/fixme';
+
+local dashboardTags = ['omni'];
+// End dashboard settings
+
+{
+  grafanaDashboards+:: {
+    [std.format('%s', dashboardFile)]:
+      dashboard.new(
+        '%(dashboardNamePrefix)s %(dashboardTitle)s' %
+           ($._config.mintel + {'dashboardTitle': dashboardTitle }),
+        time_from='now-1h',
+        uid=dashboardUID,
+        tags=($._config.mintel.dashboardTags) + dashboardTags,
+        description=dashboardDescription,
+        graphTooltip='shared_crosshair',
+      )
+
+      .addLink(link.dashboards(tags="",
+        type="link",
+        title="Workload",
+        url=dashboardWorkloadLink,
+        includeVars=true,
+        keepTime=true,
+        asDropdown=false,
+        targetBlank=true))
+
+      .addAnnotation(annotations.fluxRelease)
+      .addAnnotation(annotations.fluxAutoRelease)
+
+      .addTemplate(templates.ds)
+      .addTemplate(templates.namespace('omni', hide=true))
+      .addTemplate(templates.app_service)
+
+      .addRow(
+        row.new('Overview', height=5)
+        .addPanels(webService.overview())
+      )
+      .addRow(
+        row.new('Request / Response')
+        .addPanels(django.requestResponsePanels())
+      )
+      .addRow(
+        row.new('Resources')
+        .addPanels(django.resourcePanels())  
+      )
+      .addRow(
+        row.new('Database', collapse=true)
+        .addPanels(django.databaseOps())  
+      )
+      .addRow(
+        row.new('Celery', collapse=true)
+        .addPanels(celery.celeryPanels(serviceType='', startRow=1001))
+      )
+       .addRow(
+        row.new('Redis', collapse=true)
+        .addPanels(redis.clientPanels(serviceSelectorKey='service', serviceSelectorValue='$service.*', startRow=1002))
+        .addPanels(redis.workload(serviceSelectorKey='service', serviceSelectorValue='$service.*', startRow=1002))
+        .addPanels(redis.data(serviceSelectorKey='service', serviceSelectorValue='$service.*', startRow=1002))
+      )
+  },
+}

--- a/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
@@ -17,7 +17,7 @@ local dashboardFile = 'omni-web-overview.json';
 
 local dashboardUID = std.md5(dashboardFile);
 local dashboardLink = '/d/' + std.md5(dashboardFile);
-local dashboardWorkloadLink = '/d/fixme';
+local dashboardWorkloadLink = '/d/a164a7f0339f99e89cea5cb47e9be617';
 
 local dashboardTags = ['omni'];
 // End dashboard settings

--- a/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
@@ -8,7 +8,7 @@ local templates = import 'components/templates.libsonnet';
 local redis = import 'components/panels/redis.libsonnet';
 local django = import 'components/panels/django.libsonnet';
 local celery = import 'components/panels/celery.libsonnet';
-local webService = import 'components/panels/web-service.libsonnet';
+local webService = import 'components/panels/frontend-service.libsonnet';
 local containerResources = import 'components/panels/container_resources.libsonnet';
 
 

--- a/lib/mintel/dashboards/services/portal/overview.libsonnet
+++ b/lib/mintel/dashboards/services/portal/overview.libsonnet
@@ -9,6 +9,7 @@ local redis = import 'components/panels/redis.libsonnet';
 local django = import 'components/panels/django.libsonnet';
 local celery = import 'components/panels/celery.libsonnet';
 local webService = import 'components/panels/web-service.libsonnet';
+local containerResources = import 'components/panels/container_resources.libsonnet';
 
 // Dashboard settings
 local dashboardTitle = 'Portal';
@@ -61,7 +62,7 @@ local dashboardTags = ['portal'];
       )
       .addRow(
         row.new('Resources')
-        .addPanels(django.resourcePanels())  
+        .addPanels(containerResources.containerResourcesPanel("$service"))
       )
       .addRow(
         row.new('Database', collapse=true)

--- a/lib/mintel/dashboards/services/portal/overview.libsonnet
+++ b/lib/mintel/dashboards/services/portal/overview.libsonnet
@@ -8,7 +8,7 @@ local templates = import 'components/templates.libsonnet';
 local redis = import 'components/panels/redis.libsonnet';
 local django = import 'components/panels/django.libsonnet';
 local celery = import 'components/panels/celery.libsonnet';
-local webService = import 'components/panels/web-service.libsonnet';
+local webService = import 'components/panels/frontend-service.libsonnet';
 local containerResources = import 'components/panels/container_resources.libsonnet';
 
 // Dashboard settings

--- a/lib/mintel/mixins.libsonnet
+++ b/lib/mintel/mixins.libsonnet
@@ -1,6 +1,7 @@
 (import './config.libsonnet') +
 
 (import './alerts/blackbox.libsonnet') +
+(import './alerts/cert-manager.libsonnet') +
 (import './alerts/elasticsearch.libsonnet') +
 (import './alerts/external-dns.libsonnet') +
 (import './alerts/haproxy-ingress.libsonnet') +

--- a/lib/mintel/mixins.libsonnet
+++ b/lib/mintel/mixins.libsonnet
@@ -31,4 +31,5 @@
 (import './rules/mintel-overcommit.libsonnet') +
 (import './rules/mintel-pod.libsonnet') +
 (import './rules/mintel-web-frontend.libsonnet') +
+(import './rules/mintel-http.libsonnet') +
 (import './dashboards/dashboards.libsonnet')

--- a/lib/mintel/rules/mintel-http.libsonnet
+++ b/lib/mintel/rules/mintel-http.libsonnet
@@ -1,0 +1,31 @@
+{
+  prometheusRules+:: {
+    groups+: [
+      {
+        name: 'mintel-http.rules',
+        rules: [
+          {
+            expr: |||
+              (
+              sum by (service, app_mintel_com_owner) (rate(http_requests_total{status_code=~"5.."}[1m]))
+              /  
+              sum by (service, app_mintel_com_owner) (rate(http_requests_total[1m]))
+              ) * 100
+            |||,
+            record: 'mintel:http_error_rate:percentage:1m',
+          },
+        ] + [
+          {
+            expr: |||
+              histogram_quantile(%(quantile)s,
+                sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+              )
+            ||| % quantile,
+            record: std.format('mintel:http_request_duration_seconds_quantile:%s', std.substr(quantile, 2, 2)),
+          }
+          for quantile in ['0.50', '0.75', '0.95', '0.99']
+        ],
+      },
+    ],
+  },
+}

--- a/lib/mintel/rules/mintel-http.libsonnet
+++ b/lib/mintel/rules/mintel-http.libsonnet
@@ -18,7 +18,7 @@
           {
             expr: |||
               histogram_quantile(%(quantile)s,
-                sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+                sum without(instance, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
               )
             ||| % quantile,
             record: std.format('mintel:http_request_duration_seconds_quantile:%s', std.substr(quantile, 2, 2)),

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1256,6 +1256,45 @@ spec:
       labels:
         page: "true"
         severity: critical
+  - name: cert-manager.alerts
+    rules:
+    - alert: CertManagerCertificateExpireSoon
+      annotations:
+        description: Cert Manager managed certificate for {{ $labels.namespace }}/{{
+          $labels.name }} will expire in less then 29 days
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/CertManager.md#CertManagerCertificateExpireSoon
+        summary: Certificate managed by Cert-Manager will expire soon in less then
+          29 days
+      expr: certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"}
+        - time() < 2506000
+      for: 60m
+      labels:
+        severity: warning
+    - alert: CertManagerCertificateExpireSoon
+      annotations:
+        description: Cert Manager managed certificate for {{ $labels.namespace }}/{{
+          $labels.name }} will expire in less then 14 days
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/CertManager.md#CertManagerCertificateExpireSoon
+        summary: Certificate managed by Cert-Manager will expire soon in less then
+          14 days
+      expr: certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"}
+        - time() < 1210000
+      for: 60m
+      labels:
+        page: "true"
+        severity: critical
+    - alert: CertManagerCertificateNotReady
+      annotations:
+        description: Cert Manager certificate for {{ $labels.namespace }}/{{ $labels.name
+          }} has not reached Ready status in 60 minutes
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/CertManager.md#CertManagerCertificateNotReady
+        summary: Certificate managed by Cert-Manager has not reached Ready Status
+          in 60 minutes
+      expr: certmanager_certificate_ready_status{job="cert-manager",condition="True"}
+        == 0
+      for: 60m
+      labels:
+        severity: warning
   - name: elasticsearch.alerts
     rules:
     - alert: ElasticsearchOperatorReconcileErrors
@@ -1445,9 +1484,20 @@ spec:
         description: External DNS Last Sync is very Old
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/ExternalDNS.md#ExternalDnsLastSyncOld
         summary: External DNS Last Sync is very Old
-      expr: time() - external_dns_controller_last_sync_timestamp_seconds{job="external-dns"}
-        > 90
+      expr: (time() - external_dns_controller_last_sync_timestamp_seconds{job="external-dns"}
+        > 90) or external_dns_controller_last_sync_timestamp_seconds{job="external-dns"}
+        == 0
       for: 10m
+      labels:
+        severity: warning
+    - alert: ExternalDnsRegistryErrorsIncrease
+      annotations:
+        description: External DNS registry Errors increasing constantly
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/ExternalDNS.md#ExternalDnsRegistryErrorsIncrease
+        summary: External DNS registry Errors increasing constantly
+      expr: increase(external_dns_registry_errors_total{job="external-dns"}[5m]) >
+        0
+      for: 30m
       labels:
         severity: warning
   - name: haproxy-ingress.alerts

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -382,22 +382,22 @@ spec:
       record: mintel:http_error_rate:percentage:1m
     - expr: |
         histogram_quantile(0.50,
-          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+          sum without(instance, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
         )
       record: mintel:http_request_duration_seconds_quantile:50
     - expr: |
         histogram_quantile(0.75,
-          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+          sum without(instance, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
         )
       record: mintel:http_request_duration_seconds_quantile:75
     - expr: |
         histogram_quantile(0.95,
-          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+          sum without(instance, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
         )
       record: mintel:http_request_duration_seconds_quantile:95
     - expr: |
         histogram_quantile(0.99,
-          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+          sum without(instance, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
         )
       record: mintel:http_request_duration_seconds_quantile:99
   - name: node-exporter

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -374,6 +374,32 @@ spec:
         \ \"environment\",\n  \"$1\",\n  \"label_app_mintel_com_pipeline_stage\",\n
         \ \"(.*)\"\n)\n"
       record: mintel:web_frontend:check_up
+  - name: mintel-http.rules
+    rules:
+    - expr: "(\nsum by (service, app_mintel_com_owner) (rate(http_requests_total{status_code=~\"5..\"}[1m]))\n/
+        \ \nsum by (service, app_mintel_com_owner) (rate(http_requests_total[1m]))\n)
+        * 100\n"
+      record: mintel:http_error_rate:percentage:1m
+    - expr: |
+        histogram_quantile(0.50,
+          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+        )
+      record: mintel:http_request_duration_seconds_quantile:50
+    - expr: |
+        histogram_quantile(0.75,
+          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+        )
+      record: mintel:http_request_duration_seconds_quantile:75
+    - expr: |
+        histogram_quantile(0.95,
+          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+        )
+      record: mintel:http_request_duration_seconds_quantile:95
+    - expr: |
+        histogram_quantile(0.99,
+          sum without(instnace, endpoint, job, pod) (rate(http_request_duration_seconds_bucket[1m]))
+        )
+      record: mintel:http_request_duration_seconds_quantile:99
   - name: node-exporter
     rules:
     - alert: NodeFilesystemSpaceFillingUp

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1995,7 +1995,7 @@ spec:
         runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/flux.md#fluxdaemongeneralsyncerror
         summary: General Flux Daemon sync error
       expr: delta(flux_daemon_sync_duration_seconds_count{job="flux",success="true"}[6m])
-        < 1
+        < 1 or absent(flux_daemon_sync_duration_seconds_count{job="flux",success="true"})
       for: 120m
       labels:
         severity: warning


### PR DESCRIPTION
- Adds omni-web stack (copy of portal, since stack is similar)
- Analytics
- I added a new container-resources  component that can be used in other applications
- Added a new http (generic) panel
- Added new workload status panel
- Rename web-service -> frontend-service (since it's all about haproxy)

Analytics show:

- api-service latency
- pod usage
- es-latency
- breakdown by analytics type

