### PR TITLE
Update dev-app dashboards to limit by service

### DIFF
--- a/dashboards/rendered/omni-analytics-overview.json
+++ b/dashboards/rendered/omni-analytics-overview.json
@@ -909,7 +909,7 @@
             "multi": false,
             "name": "service",
             "options": [ ],
-            "query": "label_values(kube_service_labels{namespace=\"$namespace\"}, label_app_kubernetes_io_instance)",
+            "query": "label_values(kube_service_labels{namespace=\"$namespace\", service=~\".*omni-analytics.*\"}, label_app_kubernetes_io_instance)",
             "refresh": 1,
             "regex": "",
             "sort": 0,

--- a/dashboards/rendered/omni-web-dashboard-performance.json
+++ b/dashboards/rendered/omni-web-dashboard-performance.json
@@ -312,7 +312,7 @@
             "multi": false,
             "name": "service",
             "options": [ ],
-            "query": "label_values(kube_service_labels{namespace=\"$namespace\"}, label_app_kubernetes_io_instance)",
+            "query": "label_values(kube_service_labels{namespace=\"$namespace\", service=~\".*omni-web.*\"}, label_app_kubernetes_io_instance)",
             "refresh": 1,
             "regex": "",
             "sort": 0,

--- a/dashboards/rendered/omni-web-overview.json
+++ b/dashboards/rendered/omni-web-overview.json
@@ -2677,7 +2677,7 @@
             "multi": false,
             "name": "service",
             "options": [ ],
-            "query": "label_values(kube_service_labels{namespace=\"$namespace\"}, label_app_kubernetes_io_instance)",
+            "query": "label_values(kube_service_labels{namespace=\"$namespace\", service=~\".*omni-web.*\"}, label_app_kubernetes_io_instance)",
             "refresh": 1,
             "regex": "",
             "sort": 0,

--- a/dashboards/rendered/portal-overview.json
+++ b/dashboards/rendered/portal-overview.json
@@ -2677,7 +2677,7 @@
             "multi": false,
             "name": "service",
             "options": [ ],
-            "query": "label_values(kube_service_labels{namespace=\"$namespace\"}, label_app_kubernetes_io_instance)",
+            "query": "label_values(kube_service_labels{namespace=\"$namespace\", service=~\".*portal-web.*\"}, label_app_kubernetes_io_instance)",
             "refresh": 1,
             "regex": "",
             "sort": 0,

--- a/lib/mintel/dashboards/components/templates.libsonnet
+++ b/lib/mintel/dashboards/components/templates.libsonnet
@@ -42,11 +42,10 @@ local template = grafana.template;
     current=current,
     hide=hide,
   ),
-
-  app_service:: template.new(
+  app_service(service=''):: template.new(
     'service',
     'Prometheus',
-    'label_values(kube_service_labels{namespace="$namespace"}, label_app_kubernetes_io_instance)',
+    'label_values(kube_service_labels{namespace="$namespace", service=~".*%(service)s.*"}, label_app_kubernetes_io_instance)' % (service),
     label='Service',
     refresh='load',
   ),

--- a/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-analytics-overview.libsonnet
@@ -49,7 +49,7 @@ local dashboardTags = ['omni'];
 
       .addTemplate(templates.ds)
       .addTemplate(templates.namespace('omni', hide=true))
-      .addTemplate(templates.app_service)
+      .addTemplate(templates.app_service('omni-analytics'))
       .addTemplate(grafana.template.new(
         'analytics_type',
         'Prometheus',

--- a/lib/mintel/dashboards/services/omni/omni-web-dashboard-performance.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-web-dashboard-performance.libsonnet
@@ -47,7 +47,7 @@ local dashboardTags = ['omni'];
 
       .addTemplate(templates.ds)
       .addTemplate(templates.namespace('omni', hide=true))
-      .addTemplate(templates.app_service)
+      .addTemplate(templates.app_service('omni-web'))
       .addTemplate(templates.omni_dashboard_id)
 
       .addRow(

--- a/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
+++ b/lib/mintel/dashboards/services/omni/omni-web-overview.libsonnet
@@ -52,7 +52,7 @@ local dashboardTags = ['omni'];
 
       .addTemplate(templates.ds)
       .addTemplate(templates.namespace('omni', hide=true))
-      .addTemplate(templates.app_service)
+      .addTemplate(templates.app_service('omni-web'))
 
       .addRow(
         row.new('Overview', height=5)

--- a/lib/mintel/dashboards/services/portal/overview.libsonnet
+++ b/lib/mintel/dashboards/services/portal/overview.libsonnet
@@ -50,7 +50,7 @@ local dashboardTags = ['portal'];
 
       .addTemplate(templates.ds)
       .addTemplate(templates.namespace('portal', hide=true))
-      .addTemplate(templates.app_service)
+      .addTemplate(templates.app_service('portal-web'))
 
       .addRow(
         row.new('Overview', height=5)


### PR DESCRIPTION
This limits the services that each dashboard is allowed to show, given that the metrics between analytics vs web are different.

