### PR TITLE
Add Network Traffic Anomaly detection for

### DIFF
--- a/lib/gke-overrides.libsonnet
+++ b/lib/gke-overrides.libsonnet
@@ -15,6 +15,8 @@ local ignore_alerts = [
   'KubeSchedulerDown',
   'PrometheusRemoteStorageFailures',
   'PrometheusRemoteWriteBehind',
+  'PrometheusOutboundNetworkTrafficAnomalyDetected',
+  'PromtailOutboundNetworkTrafficAnomalyDetected',
 ];
 
 // Define a list of record rules to ignore
@@ -65,6 +67,8 @@ local page_false_critical = [
   'ElasticsearchClusterHealthYELLOW',
   'ElasticsearchHeapTooHigh',
   'ElasticsearchLowDiskFree',
+  'GoogleNatGatewayOutboundNetworkAnomalyDetection',
+  'GoogleNatGatewayInboundNetworkAnomalyDetection',
   'HAProxyFrontendSessionUsage',
   'HAProxyBackendResponseErrors',
   'HAProxyServerInBackendUpPercentageLow',
@@ -73,7 +77,9 @@ local page_false_critical = [
   'KubePodFailed',
   'PodOOMKilled',
   'PrometheusBadConfig',
-  'PrometheusErrorSendingAlertsToAnyAlertmanager',
+  'PrometheusErrorSendingAlertsToAnyAlertmanager',  // Why is this page=false ?
+  'PrometheusOutboundNetworkTrafficAnomalyDetected',
+  'PromtailOutboundNetworkTrafficAnomalyDetected',
 ];
 
 // Downgrade severity for a rule

--- a/lib/mintel/alerts/mintel-network.libsonnet
+++ b/lib/mintel/alerts/mintel-network.libsonnet
@@ -1,0 +1,93 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'mintel-network.alerts',
+        rules: [
+                 {
+                   alert: 'PrometheusOutboundNetworkTrafficAnomalyDetected',
+                   annotations: {
+                     description: 'Prometheus Pod {{ $labels.pod }} Outbound traffic Anomaly detected',
+                     runbook_url: '%(runBookBaseURL)s/core/NetworkTrafficAnomalyDetected.md' % $._config,
+                     summary: 'Prometheus Outbound Network Traffic Anomaly Detected',
+                   },
+                   expr: |||
+                     abs(
+                       sum by (pod) (
+                         ( 
+                           rate(container_network_transmit_bytes_total{namespace="monitoring", pod=~"prometheus-k8s-."}[15m]) - 
+                           avg_over_time(rate(container_network_transmit_bytes_total{namespace="monitoring", pod=~"prometheus-k8s-."}[15m])[1w:5m])
+                         ) 
+                         / avg_over_time(rate(container_network_transmit_bytes_total{namespace="monitoring", pod=~"prometheus-k8s-."}[15m])[1w:5m]) 
+                       )
+                     ) > 5
+                   |||,
+                   'for': std.format('%s', alert.interval),
+                   labels: {
+                     severity: std.format('%s', alert.severity),
+                   },
+                 }
+                 for alert in [{ severity: 'warning', interval: '10m' }, { severity: 'critical', interval: '20m' }]
+               ] +
+               [
+                 {
+                   alert: 'PromtailOutboundNetworkTrafficAnomalyDetected',
+                   annotations: {
+                     description: 'Promtail Pod {{ $labels.pod }} Outbound traffic Anomaly detected',
+                     runbook_url: '%(runBookBaseURL)s/core/NetworkTrafficAnomalyDetected.md' % $._config,
+                     summary: 'Promtail Outbound Network Traffic Anomaly Detected',
+                   },
+                   expr: |||
+                     abs(
+                       sum by (pod) (
+                         ( 
+                           rate(promtail_sent_bytes_total{pod=~"promtail-.*"}[15m]) - 
+                           avg_over_time(rate(promtail_sent_bytes_total{pod=~"promtail-.*"}[15m])[1w:5m])
+                         ) 
+                         / avg_over_time(rate(promtail_sent_bytes_total{pod=~"promtail-.*"}[15m])[1w:5m]) 
+                       )
+                     ) > 8
+                   |||,
+                   'for': std.format('%s', alert.interval),
+                   labels: {
+                     severity: std.format('%s', alert.severity),
+                   },
+                 }
+                 for alert in [{ severity: 'warning', interval: '10m' }, { severity: 'critical', interval: '20m' }]
+               ] +
+               [
+                 {
+                   alert: alert.alertname,
+                   annotations: {
+                     description: 'Google Nat Gateway {{ $labels.nat_gateway_name }} traffic Anomaly detected',
+                     runbook_url: '%(runBookBaseURL)s/core/NetworkTrafficAnomalyDetected.md' % $._config,
+                     summary: 'Google Nat Gateway Network Traffic Anomaly Detected',
+                   },
+                   expr: |||
+                     sum by (nat_gateway_name) (
+                       abs(
+                         (
+                           rate(%(metricname)s{}[15m]) -
+                           avg_over_time(rate(%(metricname)s{}[15m])[1w:5m])
+                         )
+                         / stddev_over_time(rate(%(metricname)s{}[15m])[1w:5m])
+                       ) > 0
+                     ) > %(threshold)s
+                   ||| % alert,
+                   'for': std.format('%s', alert.interval),
+                   labels: {
+                     severity: std.format('%s', alert.severity),
+                   },
+                 }
+                 for alert in [
+                   { alertname: 'GoogleNatGatewayOutboundNetworkAnomalyDetection', metricname: 'stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count', severity: 'warning', interval: '30m', threshold: 10 },
+                   { alertname: 'GoogleNatGatewayOutboundNetworkAnomalyDetection', metricname: 'stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count', severity: 'critical', interval: '60m', threshold: 10 },
+                   { alertname: 'GoogleNatGatewayInboundNetworkAnomalyDetection', metricname: 'stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count', severity: 'warning', interval: '30m', threshold: 10 },
+                   { alertname: 'GoogleNatGatewayInboundNetworkAnomalyDetection', metricname: 'stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count', severity: 'critical', interval: '60m', threshold: 10 },
+                 ]
+               ] +
+               [],
+      },
+    ],
+  },
+}

--- a/lib/mintel/config.libsonnet
+++ b/lib/mintel/config.libsonnet
@@ -2,6 +2,9 @@
   _config+:: {
     local this = self,
 
+    // Empty placeholder
+    jobs: {},
+
     // Set namespace here to allow jsonnet rendering from this directory.
     // Note, this will get overwritten by the main config (default is 'monitoring)'...
     namespace: 'monitoring',

--- a/lib/mintel/mixins.libsonnet
+++ b/lib/mintel/mixins.libsonnet
@@ -10,6 +10,7 @@
 (import './alerts/kubernetes-resources.libsonnet') +
 (import './alerts/mintel-containers.libsonnet') +
 (import './alerts/mintel-disks.libsonnet') +
+(import './alerts/mintel-network.libsonnet') +
 (import './alerts/mintel-node.libsonnet') +
 (import './alerts/mintel-overcommit.libsonnet') +
 (import './alerts/mintel-pod.libsonnet') +

--- a/rules/prometheus-rules.yaml
+++ b/rules/prometheus-rules.yaml
@@ -1813,6 +1813,86 @@ spec:
       labels:
         page: "true"
         severity: critical
+  - name: mintel-network.alerts
+    rules:
+    - alert: GoogleNatGatewayOutboundNetworkAnomalyDetection
+      annotations:
+        description: Google Nat Gateway {{ $labels.nat_gateway_name }} traffic Anomaly
+          detected
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/NetworkTrafficAnomalyDetected.md
+        summary: Google Nat Gateway Network Traffic Anomaly Detected
+      expr: |
+        sum by (nat_gateway_name) (
+          abs(
+            (
+              rate(stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count{}[15m]) -
+              avg_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count{}[15m])[1w:5m])
+            )
+            / stddev_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count{}[15m])[1w:5m])
+          ) > 0
+        ) > 10
+      for: 30m
+      labels:
+        severity: warning
+    - alert: GoogleNatGatewayOutboundNetworkAnomalyDetection
+      annotations:
+        description: Google Nat Gateway {{ $labels.nat_gateway_name }} traffic Anomaly
+          detected
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/NetworkTrafficAnomalyDetected.md
+        summary: Google Nat Gateway Network Traffic Anomaly Detected
+      expr: |
+        sum by (nat_gateway_name) (
+          abs(
+            (
+              rate(stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count{}[15m]) -
+              avg_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count{}[15m])[1w:5m])
+            )
+            / stddev_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_sent_bytes_count{}[15m])[1w:5m])
+          ) > 0
+        ) > 10
+      for: 60m
+      labels:
+        page: "false"
+        severity: critical
+    - alert: GoogleNatGatewayInboundNetworkAnomalyDetection
+      annotations:
+        description: Google Nat Gateway {{ $labels.nat_gateway_name }} traffic Anomaly
+          detected
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/NetworkTrafficAnomalyDetected.md
+        summary: Google Nat Gateway Network Traffic Anomaly Detected
+      expr: |
+        sum by (nat_gateway_name) (
+          abs(
+            (
+              rate(stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count{}[15m]) -
+              avg_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count{}[15m])[1w:5m])
+            )
+            / stddev_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count{}[15m])[1w:5m])
+          ) > 0
+        ) > 10
+      for: 30m
+      labels:
+        severity: warning
+    - alert: GoogleNatGatewayInboundNetworkAnomalyDetection
+      annotations:
+        description: Google Nat Gateway {{ $labels.nat_gateway_name }} traffic Anomaly
+          detected
+        runbook_url: https://gitlab.com/mintel/satoshi/docs/blob/master/runbooks/core/NetworkTrafficAnomalyDetected.md
+        summary: Google Nat Gateway Network Traffic Anomaly Detected
+      expr: |
+        sum by (nat_gateway_name) (
+          abs(
+            (
+              rate(stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count{}[15m]) -
+              avg_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count{}[15m])[1w:5m])
+            )
+            / stddev_over_time(rate(stackdriver_gce_instance_compute_googleapis_com_nat_received_bytes_count{}[15m])[1w:5m])
+          ) > 0
+        ) > 10
+      for: 60m
+      labels:
+        page: "false"
+        severity: critical
   - name: mintel-node.alerts
     rules:
     - alert: NodeFreeConntrackEntriesLow


### PR DESCRIPTION
* Google Nat Gateway ( stackdriver metrics )
* Prometheus Pod
* PromTail pods

this is to avoid a repetition of https://gitlab.com/mintel/satoshi/planning/-/issues/1242 which costed us ( and could cost us ) quite a bit

At the moment none of this will Page , this need to be discussed

At the moment the Prometheus and Promtail rules are disabled since without a real amount of traffic from those pods to Cortex/Loki i Can't really tell the right thresholds and false positives would arise